### PR TITLE
Link to rust-lang-nursery Rust Cookbook repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository collects resources for writing clean, idiomatic Rust code. [Plea
 * [Patterns](https://github.com/rust-unofficial/patterns) - A catalogue of Rust design patterns.
 * [Elements of Rust](https://github.com/ferrous-systems/elements-of-rust) - A collection of software engineering techniques for effectively expressing intent with Rust.
 * [Rust by Example](https://rustbyexample.com/) - A community driven collection of example code which follow Rust best practices.
-* [Rust Cookbook](https://github.com/brson/rust-cookbook) - Examples that demonstrate good practices to accomplish common programming tasks in Rust.
+* [Rust Cookbook](https://github.com/rust-lang-nursery/rust-cookbook) - Examples that demonstrate good practices to accomplish common programming tasks in Rust.
 * [rust-api-guidelines](https://github.com/brson/rust-api-guidelines) - An extensive list of recommendations for idiomatic Rust APIs.
 
 ## 🏋 Workshops


### PR DESCRIPTION
The current Rust Cookbook repository link points to a fork that hasn't been updated in almost 2 years, so I've updated it to point to the original which was updated quite recently.