### PR TITLE
Docs typo: "Kyiv" spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Contributions welcome! To add missing resources, [please refer to the contributi
 
 ### 2017
 
-* Idiomatic Rust Libraries — Rustfest Kiev [[Video](https://www.youtube.com/watch?v=0zOg8_B71gE)]
+* Idiomatic Rust Libraries — Rustfest Kyiv [[Video](https://www.youtube.com/watch?v=0zOg8_B71gE)]
 
 
 ## 💬 Forum


### PR DESCRIPTION
Hi!
Sorry for nitpicking, but 'Kiev' is an incorrect spelling of my city, Kyiv. In fact, even the video referenced uses the correct one.

'Kiev' is a Russian toponymy for a Ukrainian city, used by the Soviet Union to erase Ukrainian identity. It's not an official transliteration or translation. The incorrect spelling is widespread because of soviet heritage.

The correct spelling is **Kyiv**, not ~~Kiev~~.

Thank you for your time and attention, have a good one!
