### PR TITLE
fix: hexagonal architecture in rust article link

### DIFF
--- a/resources.json
+++ b/resources.json
@@ -523,7 +523,7 @@
   },
   {
     "title": "Hexagonal architecture in Rust",
-    "url": "https://alexis-lozano.com/hexagonal-architecture-in-rust-1/",
+    "url": "https://alexis-lozano.com/blog/hexagonal-architecture-in-rust-1/",
     "description": "Describes how to build a Rust service using domain driven design and a test-first approach.",
     "tags": [
       "architecture",


### PR DESCRIPTION
The blog author seems to have refactored his webpage, and now the blog articles sit under the /blog directory.

This commit updates the url to reflect this change.