### PR TITLE
Fix broken link to Wrapping errors in Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Contributions welcome! To add missing resources, [please refer to the contributi
 
 - [Rust Number Conversion: Don't Follow the Book...](https://blog.notmet.net/2021/12/rust-number-conversion-dont-follow-the-book.../) — A blog post discussing the best practices for number conversion in Rust.
   - [Hexagonal architecture in Rust](https://alexis-lozano.com/blog/hexagonal-architecture-in-rust-1/) — Describes how to build a Rust service using domain driven design and a test-first approach.
-  - [Wrapping errors in Rust](https://edgarluque.com/blog/wrapping-errors-in-rust) — Wrapping 'reqwest::Error' and a custom error type as an enum to make library usage easier.
+  - [Wrapping errors in Rust](https://edgl.dev/blog/wrapping-errors-in-rust/) — Wrapping 'reqwest::Error' and a custom error type as an enum to make library usage easier.
   - [Aiming for idiomatic Rust](https://web.archive.org/web/20221203043933/https://shane-o.dev/blog/aiming-for-idiomatic-rust) — Discusses different ways to solve a popular coding puzzle, 'balanced brackets', in Rust.
   - [Naming Your Lifetimes](https://www.possiblerust.com/pattern/naming-your-lifetimes) — Explains how using longer, declarative lifetime names can help to disambiguate which borrow is which.
   

--- a/resources.json
+++ b/resources.json
@@ -506,7 +506,7 @@
   },
   {
     "title": "Wrapping errors in Rust",
-    "url": "https://edgarluque.com/blog/wrapping-errors-in-rust",
+    "url": "https://edgl.dev/blog/wrapping-errors-in-rust/",
     "description": "Wrapping 'reqwest::Error' and a custom error type as an enum to make library usage easier.",
     "tags": [
       "error-handling",


### PR DESCRIPTION
fix(readme): update broken link to Wrapping errors in Rust

- Changed URL to new location: https://edgl.dev/blog/wrapping-errors-in-rust/
- Ensures documentation link is current and valid, fixing lint failures.
- Improves resource accessibility for idiomatic Rust error handling.
