### PR TITLE
Add Idiomatic Rust Snippets to Books section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Contributions welcome! To add missing resources, [please refer to the contributi
 - [Command-Line Rust](https://github.com/kyclark/command-line-rust) — Learn the language by writing Rust versions of common Unix coreutils.
 - [Discover the world of microcontrollers through Rust!](https://docs.rust-embedded.org/discovery/) — An introductory course on microcontroller-based embedded systems using Rust.
 - [High Assurance Rust](https://highassurance.rs/) — Developing secure and robust software, focusing on embedded-friendly data structures in Rust.
+- [Idiomatic Rust Snippets](https://idiomatic-rust-snippets.org/) — Beginner-friendly guide to core Rust concepts—one of the best cheat sheets for Rust developers.
 - [Programming Rust: Fast, Safe Systems Development](https://www.oreilly.com/library/view/programming-rust-2nd/9781492052586/) — A comprehensive Rust Programming Guide that covers most of Rust's features in detail.
 - [Rust Atomics and Locks](https://marabos.nl/atomics/) — Helps Rust programmers of all levels gain a clear understanding of low-level concurrency.
 - [Rust Cookbook](https://github.com/rust-lang-nursery/rust-cookbook) — Examples that demonstrate good practices to accomplish common programming tasks in Rust.

--- a/resources.json
+++ b/resources.json
@@ -299,6 +299,19 @@
     "category": "book"
   },
   {
+    "title": "Idiomatic Rust Snippets",
+    "url": "https://idiomatic-rust-snippets.org",
+    "description": "Beginner-friendly guide to core Rust concepts—one of the best cheat sheets for Rust developers.",
+    "tags": ["patterns", "idiomatic", "snippets"],
+    "official": false,
+    "year": 2025,
+    "difficultyLevel": "all",
+    "duration": null,
+    "interactivityLevel": "high",
+    "free": true,
+    "category": "book"
+  },
+  {
     "title": "Rust Cookbook",
     "url": "https://github.com/rust-lang-nursery/rust-cookbook",
     "description": "Examples that demonstrate good practices to accomplish common programming tasks in Rust.",


### PR DESCRIPTION
Hello 👋

I've added [Idiomatic Rust Snippets](https://idiomatic-rust-snippets.org) to the Books section of this collection.

Idiomatic Rust Snippets is a beginner-friendly guide that covers core Rust concepts through practical examples. 

The site complements the existing resources nicely by providing:
     - Quick, accessible code snippets
     - Coverage from basic to intermediate Rust topics
     - Real-world, practical examples
     - High interactivity for hands-on learning

I believe this resource would be valuable for developers learning idiomatic Rust. Let me know if you'd like any changes to the description or placement!

Thanks for maintaining this excellent collection! 🦀
