### PR TITLE
Add Idiomatic Rust Review skill + Claude Code plugin manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "idiomatic-rust",
+  "owner": {
+    "name": "mre"
+  },
+  "description": "Idiomatic Rust resources and a code-review skill for Claude Code.",
+  "plugins": [
+    {
+      "name": "idiomatic-rust-review",
+      "source": "./",
+      "description": "Review Rust code for idiomatic style, API ergonomics, error handling, ownership, and common anti-patterns."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "idiomatic-rust-review",
+  "description": "Review Rust code for idiomatic style, API ergonomics, error handling, ownership, and common anti-patterns.",
+  "version": "0.1.0"
+}

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Contributions welcome! To add missing resources, [please refer to the contributi
 - [cheats.rs - Idiomatic Rust tips](https://cheats.rs/) — A list of quick tips to make your code more idiomatic.
 - [clippy](https://github.com/rust-lang/rust-clippy) — A bunch of lints to catch common mistakes and improve your Rust code.
 - [Elements of Rust](https://github.com/ferrous-systems/elements-of-rust) — A collection of software engineering techniques for effectively expressing intent with Rust.
+- [Idiomatic Rust Review Skill](https://github.com/mre/idiomatic-rust/tree/master/skills/idiomatic-rust-review) — A Claude Code skill containing a peer-reviewed ruleset for reviewing Rust code, synthesized from this repository's corpus, the Rust API Guidelines, Canonical's Rust Best Practices, Elements of Rust, and Clippy's lint set.
 - [Patterns](https://rust-unofficial.github.io/patterns/) — A catalogue of design patterns in Rust.
 - [Possible Rust](https://www.possiblerust.com/) — A blog for intermediate Rust programmers exploring real-world code and design patterns.
 - [Rust Anthology](https://github.com/brson/rust-anthology) — The best short-form writing about Rust, collected.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ You can find a sortable/searchable version of this list [here](https://corrode.d
 
 Contributions welcome! To add missing resources, [please refer to the contributing documentation](https://github.com/mre/idiomatic-rust/blob/master/CONTRIBUTING.md).
 
+## 🤖 Use as a Claude Code Skill
+
+This repository ships an installable [Claude Code](https://claude.com/claude-code) skill that applies the rules in this corpus as a code review.
+
+Install it from the Claude Code plugin marketplace:
+
+```sh
+/plugin marketplace add mre/idiomatic-rust
+/plugin install idiomatic-rust-review@idiomatic-rust
+```
+
+The skill activates automatically when you ask Claude Code to review Rust code, refactor a `.rs` file, or when the conversation contains Rust source. To remove it: `/plugin uninstall idiomatic-rust-review@idiomatic-rust`.
+
+Source: [`skills/idiomatic-rust-review/`](skills/idiomatic-rust-review/).
+
 ## ⚙ Projects
 
 - [blessed.rs](https://blessed.rs/crates) — An unofficial guide to the Rust ecosystem. Suggestions for popular, well-maintained crates.

--- a/render/templates/README.md
+++ b/render/templates/README.md
@@ -21,6 +21,21 @@ You can find a sortable/searchable version of this list [here](https://corrode.d
 
 Contributions welcome! To add missing resources, [please refer to the contributing documentation](https://github.com/mre/idiomatic-rust/blob/master/CONTRIBUTING.md).
 
+## 🤖 Use as a Claude Code Skill
+
+This repository ships an installable [Claude Code](https://claude.com/claude-code) skill that applies the rules in this corpus as a code review.
+
+Install it from the Claude Code plugin marketplace:
+
+```sh
+/plugin marketplace add mre/idiomatic-rust
+/plugin install idiomatic-rust-review@idiomatic-rust
+```
+
+The skill activates automatically when you ask Claude Code to review Rust code, refactor a `.rs` file, or when the conversation contains Rust source. To remove it: `/plugin uninstall idiomatic-rust-review@idiomatic-rust`.
+
+Source: [`skills/idiomatic-rust-review/`](skills/idiomatic-rust-review/).
+
 ## ⚙ Projects
 
 {% for project in projects -%}

--- a/resources.json
+++ b/resources.json
@@ -130,6 +130,19 @@
     "category": "project"
   },
   {
+    "title": "Idiomatic Rust Review Skill",
+    "url": "https://github.com/mre/idiomatic-rust/tree/master/skills/idiomatic-rust-review",
+    "description": "A Claude Code skill containing a peer-reviewed ruleset for reviewing Rust code, synthesized from this repository's corpus, the Rust API Guidelines, Canonical's Rust Best Practices, Elements of Rust, and Clippy's lint set.",
+    "tags": ["review", "skill", "ruleset", "best-practices"],
+    "official": false,
+    "year": 2026,
+    "difficultyLevel": "all",
+    "duration": null,
+    "interactivityLevel": "low",
+    "free": true,
+    "category": "project"
+  },
+  {
     "title": "Comprehensive Rust",
     "url": "https://github.com/google/comprehensive-rust",
     "description": "A four day Rust course developed by the Android team, covering all aspects of Rust.",

--- a/skills/idiomatic-rust-review/SKILL.md
+++ b/skills/idiomatic-rust-review/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: idiomatic-rust-review
+description: Review Rust code for idiomatic style, API ergonomics, error handling, ownership, and common anti-patterns. Use this skill whenever reviewing, critiquing, or refactoring Rust source files (.rs), Cargo crates, pull requests touching Rust, or whenever the user asks "is this idiomatic Rust?", "review my Rust code", "what's the more Rusty way to write this?", or anything similar. Trigger even when the user just pastes Rust code without an explicit review request, since the most useful response is usually a review against these rules.
+---
+
+# Idiomatic Rust Reviewer
+
+A peer-reviewed ruleset for reviewing Rust code. Synthesized from the resources collected at [mre/idiomatic-rust](https://github.com/mre/idiomatic-rust), the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/), [Canonical's Rust Best Practices](https://canonical.github.io/rust-best-practices/), [Elements of Rust](https://github.com/ferrous-systems/elements-of-rust), and [Clippy](https://github.com/rust-lang/rust-clippy)'s lint set.
+
+## How to use this skill
+
+1. **Triage** the code by scope: is it a binary, a library, an async runtime, an FFI boundary, embedded? The right rules differ — libraries are stricter about API design and `#![deny(missing_docs)]`; binaries can use `anyhow` and `unwrap` more freely.
+2. **Read the relevant category file(s)** from `references/` before commenting (see index below).
+3. **Cite the rule ID** (e.g. `ERR-04`) and the source resource when flagging an issue. This lets the author trace your reasoning.
+4. **Show, don't just tell** — every finding should include a minimal anti-pattern → pattern rewrite.
+5. **Order findings by severity**: `MUST` first, then `SHOULD`, then `MAY`.
+6. **Don't pile on**. Pick the highest-value 5–10 findings unless the user asks for exhaustive review. Idiomatic Rust includes knowing what *not* to nitpick.
+
+## Severity scheme
+
+Each rule is tagged with one of:
+
+- **MUST** — A bug, soundness issue, or violation of a near-universal convention. Always flag.
+- **SHOULD** — A clear improvement in clarity, ergonomics, or safety. Flag unless context justifies the exception.
+- **MAY** — A stylistic preference or micro-optimization. Flag only when the user asks for thorough review or it materially helps readability.
+
+## Rule index
+
+| Category | File | What it covers |
+| --- | --- | --- |
+| Error handling | `references/error-handling.md` | `Result`, `Option`, `?`, `panic`, `unwrap`, `thiserror`/`anyhow`, error context |
+| Types & conversions | `references/types-and-conversions.md` | Newtypes, `From`/`Into`/`TryFrom`, `AsRef`, `Cow`, enums vs booleans, string types |
+| Ownership & lifetimes | `references/ownership-and-lifetimes.md` | Borrowing, lifetime elision, naming lifetimes, `Clone`/`Copy`, `&str` vs `String` in APIs |
+| Iterators & collections | `references/iterators-and-collections.md` | Iterator chains vs loops, `collect`, `Iterator` on `Result`/`Option`, allocation patterns |
+| API design | `references/api-design.md` | Builder pattern, accepting `impl AsRef<Path>`, sealed traits, `#[must_use]`, re-exports |
+| Async & concurrency | `references/async-and-concurrency.md` | `Send`/`Sync` bounds, cancellation, async traits, `Mutex` in async, structured concurrency |
+| Pattern matching | `references/pattern-matching.md` | Exhaustive matches, `if let` pitfalls, `matches!`, refutable patterns, guards |
+| Documentation & naming | `references/documentation-and-naming.md` | Doc tests, `# Errors`/`# Panics`/`# Safety` sections, naming conventions |
+| Unsafe & performance | `references/unsafe-and-performance.md` | `unsafe` invariants, `transmute`, `unwrap_unchecked`, allocation hot paths |
+| Common anti-patterns | `references/anti-patterns.md` | Over-engineering, premature `Arc<Mutex<…>>`, out-parameters, leaky abstractions |
+| Rule index (flat list) | `references/rule-index.md` | Searchable one-line table of every rule, severity, and source file |
+| Worked example | `references/example-review.md` | A complete before/after review showing the output format in action |
+
+## Top-tier rules (the ones AI reviewers miss most)
+
+These show up across nearly every resource in the corpus. Hold them in working memory even if you don't read any reference file:
+
+### R-1 (MUST) — No `unwrap`/`expect`/`panic!` in library code on user input paths
+*Sources: [Three Kinds Of Unwrap](https://zkrising.com/writing/three-unwraps/), [To panic or not to panic](https://www.ncameron.org/blog/to-panic-or-not-to-panic/), Rust API Guidelines C-FAILURE.*
+
+`unwrap` is acceptable for:
+- Tests, examples, prototypes.
+- Invariants the compiler can't see, **with an `.expect("reason")` message** that documents *why* it can't fail.
+- `main()` returning `Result` is preferred over `unwrap` chains; use `anyhow::Result<()>` in binaries.
+
+```rust
+// BAD
+let config = std::fs::read_to_string("config.toml").unwrap();
+
+// GOOD
+let config = std::fs::read_to_string("config.toml")
+    .context("failed to read config.toml")?;
+
+// ACCEPTABLE — invariant documented
+let first = items.first().expect("items is non-empty: checked above");
+```
+
+### R-2 (SHOULD) — Accept the most general input, return the most specific output
+*Sources: [Taking string arguments in Rust](http://xion.io/post/code/rust-string-args.html), [Elegant Library APIs in Rust](https://deterministic.space/elegant-apis-in-rust.html).*
+
+Parameters should take `&str`, `&[T]`, `impl AsRef<Path>`, `impl IntoIterator<Item = T>` — not `String`, `Vec<T>`, `PathBuf`. Return owned, concrete types so callers can use them flexibly.
+
+```rust
+// BAD
+fn open_log(path: String) -> Box<dyn Read> { … }
+
+// GOOD
+fn open_log(path: impl AsRef<Path>) -> io::Result<File> { … }
+```
+
+### R-3 (SHOULD) — Use enums instead of booleans for domain state
+*Source: [Rust Patterns: Enums Instead Of Booleans](https://blakesmith.me/2019/05/07/rust-patterns-enums-instead-of-booleans.html).*
+
+```rust
+// BAD
+fn send_email(addr: &str, is_html: bool, is_urgent: bool) { … }
+// call site: send_email(addr, true, false) — what do those bools mean?
+
+// GOOD
+enum Format { Plain, Html }
+enum Priority { Normal, Urgent }
+fn send_email(addr: &str, format: Format, priority: Priority) { … }
+```
+
+Bonus: a third state (`Markdown`) becomes a non-breaking addition instead of a flag explosion.
+
+### R-4 (SHOULD) — Use newtypes for domain values that aren't interchangeable
+*Source: [The Ultimate Guide to Rust Newtypes](https://www.howtocodeit.com/articles/ultimate-guide-rust-newtypes).*
+
+If a function takes a `u64` user ID and a `u64` order ID, the compiler will happily let you swap them. Newtype them.
+
+```rust
+// BAD
+fn transfer(from: u64, to: u64, amount: u64) { … }
+
+// GOOD
+struct UserId(u64);
+struct Cents(u64);
+fn transfer(from: UserId, to: UserId, amount: Cents) { … }
+```
+
+### R-5 (MUST) — Don't fight the borrow checker with `clone()` or `Rc<RefCell<_>>` reflexively
+*Sources: [Don't Worry About Lifetimes](https://corrode.dev/blog/lifetimes/), [Strategies for solving "cannot move out of"](https://hermanradtke.com/2015/06/09/strategies-for-solving-cannot-move-out-of-borrowing-errors-in-rust.html/).*
+
+Reflexive `.clone()` on every borrow error or wrapping every field in `Rc<RefCell<T>>` is the #1 sign of a non-idiomatic Rust codebase. Most of the time the fix is restructuring data flow: split a struct, take `&mut self` later, use iterators, or return owned data once at the end. Flag these patterns and suggest the structural fix.
+
+### R-6 (SHOULD) — Prefer iterator chains over index-based loops
+*Source: [Effectively Using Iterators In Rust](https://hermanradtke.com/2015/06/22/effectively-using-iterators-in-rust.html/), [Rust Iterators Beyond the Basics](https://blog.jetbrains.com/rust/2024/03/12/rust-iterators-beyond-the-basics-part-i-building-blocks/).*
+
+```rust
+// BAD
+let mut sum = 0;
+for i in 0..v.len() {
+    if v[i] > 0 { sum += v[i]; }
+}
+
+// GOOD
+let sum: i64 = v.iter().filter(|&&x| x > 0).sum();
+```
+
+But: don't chain iterators past the point where a `for` loop would be clearer. Idiomatic ≠ point-free.
+
+### R-7 (MUST) — Use `?` for error propagation, not `match` returning `Err(e)`
+*Source: [Error Handling in Rust (BurntSushi)](https://burntsushi.net/rust-error-handling/).*
+
+```rust
+// BAD
+let x = match foo() { Ok(x) => x, Err(e) => return Err(e.into()) };
+
+// GOOD
+let x = foo()?;
+```
+
+### R-8 (SHOULD) — Library errors: `thiserror`. Application errors: `anyhow` (or `eyre`)
+*Sources: [Context-preserving error handling](https://kazlauskas.me/entries/errors), [Designing Error Types in Rust Libraries](https://d34dl0ck.me/rust-bites-designing-error-types-in-rust-libraries/).*
+
+- **Library** = the caller wants to match on error variants → `thiserror`-derived enum with `#[from]` for conversions and `#[source]` for chaining.
+- **Application** = the caller logs the error → `anyhow::Result` with `.context("...")` at boundary calls.
+
+A library exposing `Box<dyn Error>` or `anyhow::Error` in its public API is a code smell (callers can't match on it).
+
+### R-9 (SHOULD) — Make illegal states unrepresentable
+*Sources: [Compile-Time Invariants in Rust](https://corrode.dev/blog/compile-time-invariants/), [Patterns for Defensive Programming in Rust](https://corrode.dev/blog/defensive-programming/).*
+
+```rust
+// BAD — both can be Some or None independently
+struct Connection { host: Option<String>, port: Option<u16> }
+
+// GOOD
+enum Connection { Disconnected, Connected { host: String, port: u16 } }
+```
+
+Typestate, sealed enums, and newtype constructors that validate on creation push errors from runtime to compile-time.
+
+### R-10 (SHOULD) — `if let` chains can deadlock with `Mutex` / `RwLock`
+*Source: [Rust's Sneaky Deadlock With if let Blocks](https://brooksblog.bearblog.dev/rusts-sneaky-deadlock-with-if-let-blocks/).*
+
+The temporary from `mutex.lock()` lives until the end of the `if let` block, not the end of the expression. In async contexts this is even worse — you can hold a lock across an `.await`.
+
+```rust
+// BAD — lock held for the whole if-let body
+if let Some(x) = self.cache.lock().unwrap().get(&key) {
+    // expensive_io may need the same lock — deadlock
+    expensive_io(x).await;
+}
+
+// GOOD — lock scope is explicit and minimal
+let value = {
+    let guard = self.cache.lock().unwrap();
+    guard.get(&key).cloned()
+};
+if let Some(x) = value { expensive_io(x).await; }
+```
+
+### R-11 (MAY) — Aim for immutability
+*Source: [Aim For Immutability in Rust](https://corrode.dev/blog/immutability/).*
+
+`let mut` should be the exception, not the default. If you find yourself writing `let mut x = …; x = …;` reach for iterators, `match`, or block expressions that evaluate to the final value.
+
+### R-12 (SHOULD) — Run Clippy, treat warnings as findings
+*Source: [Clippy](https://github.com/rust-lang/rust-clippy).*
+
+Before authoring detailed review comments, check whether `cargo clippy -- -W clippy::pedantic` would have caught the issue. If yes, recommend enabling the lint at the crate level rather than commenting case-by-case. Common ones worth promoting to `deny`:
+- `clippy::unwrap_used`, `clippy::expect_used` (library code)
+- `clippy::needless_pass_by_value`
+- `clippy::redundant_clone`
+- `clippy::missing_errors_doc`, `clippy::missing_panics_doc` (libraries)
+
+## Reviewer process checklist
+
+Walk this in order on first read:
+
+1. **Compile mentally**: Does the API surface make sense? What types cross module boundaries?
+2. **Error handling**: Skim for `unwrap`, `expect`, `?`, `panic!`. Tag rule R-1, R-7, R-8.
+3. **Public types**: Are they `String`/`Vec`/`PathBuf` where they could be `&str`/`&[T]`/`AsRef<Path>`? R-2.
+4. **Primitive obsession**: Bare `bool`/`u64`/`String` parameters that represent domain concepts. R-3, R-4.
+5. **Borrow patterns**: Look for `Rc<RefCell<_>>`, gratuitous `.clone()`, `.to_owned()` chains. R-5.
+6. **Loops**: Could it be an iterator? Always? Sometimes the loop is clearer — say so. R-6.
+7. **Locks across await / `if let`**: Critical for async code. R-10.
+8. **Documentation**: Public items missing `///` docs, missing `# Errors` / `# Panics` / `# Safety`. See `references/documentation-and-naming.md`.
+9. **Unsafe blocks**: Each `unsafe` block needs a `// SAFETY:` comment explaining the invariants. See `references/unsafe-and-performance.md`.
+
+## What NOT to flag
+
+A good reviewer earns trust by *not* nitpicking. Skip these unless asked:
+
+- Function ordering inside a module.
+- `use` statement style (let `rustfmt` handle it).
+- `&self` vs `self: &Self` — both are fine.
+- Naming bikesheds on private items.
+- Choice of `let-else` vs `match` vs `if let` when all read clearly.
+- Whether to use `format!` vs `concat!` vs `+` for short strings.
+- Comments that the user clearly wrote intentionally.
+
+## Output format for review
+
+When delivering a review, structure it as:
+
+```
+## Summary
+<2-3 sentence overall assessment>
+
+## MUST
+- **[R-1] file.rs:42** — unwrap on user input path
+  <anti-pattern snippet>
+  <suggested rewrite>
+  Source: <link>
+
+## SHOULD
+- ...
+
+## MAY (optional polish)
+- ...
+
+## Strengths
+<what the author got right — always include this>
+```
+
+The `Strengths` section is not optional. Idiomatic review culture is collaborative; pure criticism produces defensive authors and worse code over time.

--- a/skills/idiomatic-rust-review/references/anti-patterns.md
+++ b/skills/idiomatic-rust-review/references/anti-patterns.md
@@ -1,0 +1,289 @@
+# Common Anti-Patterns
+
+Sources: [The Four Horsemen of Bad Rust Code](https://github.com/corrode/four-horsemen-talk), [Be Simple](https://corrode.dev/blog/simple/), [The Mediocre Programmer's Guide to Rust](https://www.hezmatt.org/~mpalmer/blog/2024/05/01/the-mediocre-programmers-guide-to-rust.html), [Pitfalls of Safe Rust](https://corrode.dev/blog/pitfalls-of-safe-rust/), [Rustic Bits](https://llogiq.github.io/2016/02/11/rustic.html), [Are out parameters idiomatic in Rust?](https://steveklabnik.com/writing/are-out-parameters-idiomatic-in-rust/).
+
+---
+
+## ANTI-01 (MUST) — Over-engineering: traits for one impl
+
+If you write a trait and then write exactly one `impl` of it, you've added indirection for nothing. Wait until there's a second implementation before generalizing.
+
+```rust
+// BAD — abstraction for a future that may never come
+trait UserRepository { fn get(&self, id: u64) -> Option<User>; }
+struct PostgresUserRepository { … }
+impl UserRepository for PostgresUserRepository { … }
+
+// GOOD — start concrete; extract the trait when you actually need to swap
+struct UserRepository { db: PgPool }
+impl UserRepository { fn get(&self, id: u64) -> Option<User> { … } }
+```
+
+This is sometimes called "speculative generality." When the second implementation arrives, *then* extract the trait — the second use case will tell you what should and shouldn't be in it.
+
+## ANTI-02 (MUST) — Premature `Arc<Mutex<T>>` everywhere
+
+A sign of porting from a GC language. Shared mutable state is rarely the right answer in Rust; usually one of these is better:
+
+- An owned value with `&mut` plumbed where needed.
+- An actor task that owns the state, communicated to via a channel.
+- An `Arc<T>` of immutable data + per-thread state.
+- An `Arc<RwLock<T>>` when reads vastly outnumber writes.
+
+Flag any struct with multiple `Arc<Mutex<...>>` fields and ask whether the design can be inverted.
+
+## ANTI-03 (SHOULD) — Stringly-typed APIs
+
+```rust
+// BAD
+fn run(action: &str, args: &[&str]) { … }
+run("delete", &["force", "recursive"]);
+
+// GOOD
+enum Action { Create, Delete { force: bool, recursive: bool } }
+fn run(action: Action) { … }
+```
+
+A function taking a `&str` and dispatching on its value is asking for typos and missing arms.
+
+## ANTI-04 (MUST) — `unwrap()` chains in production code
+
+```rust
+// BAD
+let user = db.query("SELECT * FROM users WHERE id = ?", &[id])
+    .unwrap()
+    .into_iter()
+    .next()
+    .unwrap()
+    .into_user()
+    .unwrap();
+```
+
+Each `unwrap` is a future support ticket. Replace with `?` propagation and a sensible error type.
+
+## ANTI-05 (SHOULD) — Out-parameters (mutate-via-`&mut` instead of return)
+
+In Rust, prefer returning new values to mutating arguments. Out-parameters are a C/C++ habit and don't survive contact with the borrow checker well.
+
+```rust
+// BAD
+fn compute(input: &Input, output: &mut Output) { … }
+
+// GOOD
+fn compute(input: &Input) -> Output { … }
+```
+
+Exceptions:
+- The output is a `Vec`/`String` and the caller wants to reuse the allocation (`vec.clear(); fill(&mut vec);`).
+- The output is huge and you want to avoid a move (rare; `Vec` is just a pointer).
+
+## ANTI-06 (SHOULD) — `Box<dyn Error>` in library return types
+
+Opaque, can't be matched on, prevents structured error handling. See `ERR-04`. Acceptable in binaries and tests where the only consumer is a logger or `?`.
+
+## ANTI-07 (MUST) — Reinventing the standard library
+
+```rust
+// BAD
+fn is_empty<T>(v: &Vec<T>) -> bool { v.len() == 0 }
+
+// JUST USE
+v.is_empty()
+```
+
+Common reinventions to flag:
+- Custom `Result` types when `Result<T, E>` works.
+- Custom option-like enums when `Option<T>` works.
+- Custom iterator structs when `impl Iterator` of standard combinators works.
+- Hand-rolled `min`/`max`/`sort` instead of slice methods.
+
+## ANTI-08 (SHOULD) — Indexing in loops when iteration would do
+
+```rust
+// BAD
+for i in 0..v.len() { do_something(&v[i]); }
+
+// GOOD
+for x in &v { do_something(x); }
+
+// GOOD (with index)
+for (i, x) in v.iter().enumerate() { … }
+```
+
+Indexing has bounds-check cost and obscures intent.
+
+## ANTI-09 (SHOULD) — `if x == true` / `if x == false` / `match bool`
+
+```rust
+// BAD
+if is_ready == true { … }
+if is_ready == false { … }
+match is_ready { true => …, false => … }
+
+// GOOD
+if is_ready { … }
+if !is_ready { … }
+```
+
+`clippy::bool_comparison`, `clippy::match_bool`.
+
+## ANTI-10 (SHOULD) — `.to_string()` then immediately borrow
+
+```rust
+// BAD
+fn greet(name: &str) -> String { format!("hi, {}", name) }
+let s = "world".to_string();
+greet(&s);
+
+// GOOD
+greet("world");
+```
+
+Each `.to_string()` is an allocation. Most idiomatic Rust code allocates only when storing or returning.
+
+## ANTI-11 (SHOULD) — `format!("{}", x)` instead of `x.to_string()` (or vice versa, in the wrong situation)
+
+- For a single value, `x.to_string()` is clearer and slightly faster.
+- For composing multiple values, `format!("{a}-{b}")` is clearer than chaining `+` or `push_str`.
+
+```rust
+// REDUNDANT
+let s = format!("{}", x);
+
+// IDIOMATIC
+let s = x.to_string();
+```
+
+## ANTI-12 (MUST) — Returning `&'static str` via `Box::leak` to satisfy a lifetime
+
+```rust
+// BAD — leaks memory every call
+fn name(id: u32) -> &'static str {
+    Box::leak(format!("user-{id}").into_boxed_str())
+}
+
+// GOOD — return owned String
+fn name(id: u32) -> String { format!("user-{id}") }
+```
+
+If you genuinely need `'static`, use `Arc<str>` or a string interner (`string-cache`, `lasso`, `internment`).
+
+## ANTI-13 (SHOULD) — `clone()` arguments to call a function
+
+If a function takes ownership, ask whether it really needs to. Often `&T` or `&[T]` is enough.
+
+```rust
+// BAD (when send() doesn't actually need ownership)
+send(message.clone());
+println!("sent: {}", message);
+
+// GOOD — change send to take &Message
+send(&message);
+println!("sent: {}", message);
+```
+
+## ANTI-14 (MAY) — Over-using macros for things functions can do
+
+```rust
+// BAD — macros are great, but not for everything
+macro_rules! add { ($a:expr, $b:expr) => { $a + $b } }
+
+// GOOD
+fn add(a: i32, b: i32) -> i32 { a + b }
+```
+
+Reach for macros when you need variadic arguments, repetition, syntax extension, or compile-time code generation. Don't reach for them as "fast functions."
+
+## ANTI-15 (SHOULD) — `match` on a single boolean condition
+
+```rust
+// BAD
+match check() {
+    true => proceed(),
+    false => abort(),
+}
+
+// GOOD
+if check() { proceed() } else { abort() }
+```
+
+## ANTI-16 (SHOULD) — Naming variables `result`, `tmp`, `data`, `value`
+
+These names tell you nothing. Use the type or domain term.
+
+```rust
+// BAD
+let result = parse_config(&s);
+let tmp = result.users;
+for value in tmp { process(value); }
+
+// GOOD
+let config = parse_config(&s);
+for user in config.users { process(user); }
+```
+
+`result` is acceptable when the function literally returns a `Result` to be inspected immediately.
+
+## ANTI-17 (SHOULD) — Returning `Result<(), Error>` from `main` instead of `unwrap`-chains
+
+```rust
+// BAD
+fn main() {
+    let cfg = load_config().unwrap();
+    let srv = bind(&cfg).unwrap();
+    srv.run().unwrap();
+}
+
+// GOOD
+fn main() -> anyhow::Result<()> {
+    let cfg = load_config()?;
+    let srv = bind(&cfg)?;
+    srv.run()?;
+    Ok(())
+}
+```
+
+`anyhow::Result` formats the chain on exit.
+
+## ANTI-18 (SHOULD) — Long parameter lists without grouping
+
+```rust
+// BAD
+fn connect(host: &str, port: u16, user: &str, pass: &str,
+           tls: bool, timeout: Duration, retries: u8) { … }
+
+// GOOD
+struct ConnectionParams { host: String, port: u16, … }
+fn connect(params: &ConnectionParams) { … }
+// or a builder; see API-03
+```
+
+The threshold is roughly 4–5 parameters. Beyond that, group them.
+
+## ANTI-19 (MAY) — Trailing `return` statements
+
+```rust
+// BAD
+fn add(a: i32, b: i32) -> i32 { return a + b; }
+
+// GOOD
+fn add(a: i32, b: i32) -> i32 { a + b }
+```
+
+Trailing `return` is fine for early returns from a loop or branch; gratuitous at the end of a function.
+
+## ANTI-20 (SHOULD) — Reinventing builders for two-field structs
+
+If `Foo { a, b }` works as a literal, you don't need `Foo::builder().a(...).b(...).build()`. The builder pattern earns its complexity at >3 optional parameters.
+
+## ANTI-21 (MUST) — `assert_eq!(x, true)` / `assert_eq!(x, false)` instead of `assert!(x)` / `assert!(!x)`
+
+```rust
+// BAD
+assert_eq!(condition, true);
+
+// GOOD
+assert!(condition);
+```
+
+`clippy::bool_assert_comparison`.

--- a/skills/idiomatic-rust-review/references/api-design.md
+++ b/skills/idiomatic-rust-review/references/api-design.md
@@ -1,0 +1,212 @@
+# API Design
+
+Sources: [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/), [Elegant Library APIs in Rust](https://deterministic.space/elegant-apis-in-rust.html), [Rust traits for developer friendly libraries](https://benashford.github.io/blog/2015/05/24/rust-traits-for-developer-friendly-libraries/), [Nine Rules for Elegant Rust Library APIs](https://www.youtube.com/watch?v=6-8-9ZV-2WQ), [Ergonomic APIs for hard problems](https://www.youtube.com/watch?v=Phk0C-kLlho), [Teaching libraries through good documentation](https://deterministic.space/teaching-libraries.html), [Tricks of the Trait](https://www.youtube.com/watch?v=7DOYtnCXucw).
+
+---
+
+## API-01 (MUST) — Derive `Debug` on every public type
+
+Without `Debug`, callers can't `println!("{:?}", x)`, `assert_eq!` in tests, or use logging macros. Cost: nearly nothing. Default to deriving it.
+
+```rust
+// BAD
+pub struct Config { /* fields */ }
+
+// GOOD
+#[derive(Debug)]
+pub struct Config { /* fields */ }
+```
+
+For types with sensitive fields, implement `Debug` manually and redact those fields rather than skipping the trait entirely.
+
+## API-02 (SHOULD) — Derive the standard quartet where it makes sense
+
+For value-like types: `Debug, Clone, PartialEq, Eq` is the baseline. Add `Hash` if it'll be a map key, `PartialOrd, Ord` if it'll be sorted, `Copy` only if all fields are `Copy` *and* copying is conceptually cheap.
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct UserId(String);
+```
+
+## API-03 (SHOULD) — Builder pattern for >3 parameters or many optional fields
+
+A function with 7 parameters where 5 are `Option<T>` is a builder hiding from itself.
+
+```rust
+// BAD
+pub fn new(host: &str, port: u16, tls: bool, timeout: Option<Duration>,
+           retries: Option<u8>, pool_size: Option<usize>, user_agent: Option<String>) -> Client { … }
+
+// GOOD
+let client = Client::builder()
+    .host("example.com")
+    .port(443)
+    .tls(true)
+    .timeout(Duration::from_secs(30))
+    .build()?;
+```
+
+For libraries, the [`bon`](https://docs.rs/bon) and `derive_builder` crates generate this. Hand-rolling is fine for small APIs.
+
+## API-04 (SHOULD) — `#[must_use]` on functions whose return value carries meaning
+
+`Result`, `Future`, and types whose construction has no side effect benefit from `#[must_use]`. The compiler warns when callers discard the return.
+
+```rust
+#[must_use = "this `Result` may be an `Err` variant, which should be handled"]
+pub fn save(&self) -> Result<(), SaveError> { … }
+```
+
+Common cases to flag:
+- A builder method that returns `self` (the build is wasted if dropped).
+- A function returning a `MustUseDrop`-style RAII guard.
+- A `Result` that *isn't* `()` and clearly indicates work to do.
+
+## API-05 (SHOULD) — Return concrete types from public functions; take generic inputs
+
+```rust
+// BAD — caller has to name an opaque type or `Box<dyn>`
+pub fn iter() -> impl Iterator<Item = &str> { … }
+
+// GOOD — concrete struct, fully documented, can implement traits later
+pub fn iter(&self) -> Iter<'_> { Iter { … } }
+```
+
+Exception: `impl Trait` in return position is fine for combinator-style helpers where naming the concrete type would be painful (closures, iterator chains). But know you're closing the door to future trait impls on that return type.
+
+## API-06 (MUST) — Don't expose internal types in public APIs
+
+If your public function returns `internal::FooParser`, every consumer is now coupled to that path. Wrap or re-export.
+
+```rust
+// BAD — leaks impl detail
+pub fn parser() -> crate::internal::ParserImpl { … }
+
+// GOOD
+pub use crate::internal::ParserImpl as Parser;
+pub fn parser() -> Parser { … }
+```
+
+## API-07 (SHOULD) — Use `#[non_exhaustive]` on public enums and structs that may grow
+
+```rust
+#[non_exhaustive]
+pub enum Event { Connected, Disconnected, MessageReceived(String) }
+```
+
+Now adding `Reconnecting` later isn't a breaking change — downstream `match`es are forced to include a wildcard arm.
+
+## API-08 (SHOULD) — Sealed traits when you don't want downstream impls
+
+```rust
+mod sealed { pub trait Sealed {} }
+
+pub trait MyTrait: sealed::Sealed { /* methods */ }
+
+impl sealed::Sealed for MyType {}
+impl MyTrait for MyType { /* … */ }
+```
+
+This lets you add required methods later without a breaking change. Use when the trait is conceptually closed (e.g., "things that are HTTP methods").
+
+## API-09 (SHOULD) — `From`/`TryFrom` for value conversions
+
+Don't invent `to_other_type()`/`from_other_type()` when the standard traits exist. They compose with `?`, `.into()`, and trait bounds.
+
+```rust
+// BAD
+impl Url { pub fn from_string(s: String) -> Result<Self, _> { … } }
+
+// GOOD
+impl TryFrom<String> for Url { type Error = ParseError; fn try_from(s: String) -> … }
+impl FromStr for Url     { type Err = ParseError;     fn from_str(s: &str) -> …  }
+```
+
+## API-10 (MUST) — Constructors named `new`, fallible constructors named `try_new` or just take `&str`
+
+| Pattern | Name |
+| --- | --- |
+| Infallible constructor | `Type::new(...)` |
+| Fallible constructor   | `Type::try_new(...)` or `TryFrom`/`FromStr` |
+| Default value          | `impl Default` |
+| Conversion from another type | `From`/`TryFrom` |
+| Constructor from raw parts | `from_raw_parts` (often `unsafe`) |
+
+Avoid `Type::create`, `Type::build`, `Type::make` — they hint at builders without committing.
+
+## API-11 (SHOULD) — Re-export everything users need from the crate root
+
+A library where users have to write `use mylib::internal::types::config::Config` is painful. Re-export at the root.
+
+```rust
+// lib.rs
+pub use config::Config;
+pub use client::{Client, ClientBuilder};
+pub use error::Error;
+```
+
+Document the prelude pattern if there are many: `pub mod prelude { pub use crate::{Client, Config, Error}; }`.
+
+## API-12 (SHOULD) — Use the orphan rule to your advantage, but warn about coherence
+
+In your own crate you can impl your trait for foreign types and foreign traits for your types. But don't impl `Display` for a foreign type — that's downstream's job. Conflicts at link-time are nightmares.
+
+## API-13 (MAY) — `Default` implementations that match `new()`
+
+If `MyType::new()` takes no arguments, also `impl Default`. They should produce the same value. This lets `MyType::default()` work in generic contexts (`HashMap`, `serde`).
+
+```rust
+impl Default for Config {
+    fn default() -> Self { Self::new() }
+}
+```
+
+## API-14 (SHOULD) — Don't return `&Vec<T>`; return `&[T]`
+
+Returning `&Vec<T>` leaks the container type and prevents the caller from being container-agnostic.
+
+```rust
+// BAD
+pub fn items(&self) -> &Vec<Item> { &self.items }
+
+// GOOD
+pub fn items(&self) -> &[Item] { &self.items }
+```
+
+## API-15 (SHOULD) — Iterators over collections, not collections
+
+Returning an iterator lets callers `take(10)`, `filter`, `collect` into a different container.
+
+```rust
+// BAD
+pub fn names(&self) -> Vec<String> { self.users.iter().map(|u| u.name.clone()).collect() }
+
+// GOOD
+pub fn names(&self) -> impl Iterator<Item = &str> + '_ {
+    self.users.iter().map(|u| u.name.as_str())
+}
+```
+
+## API-16 (MUST) — Mark experimental APIs with `#[doc(hidden)]` or a `__private` module
+
+If you need to expose an item to macros or sister crates but don't want it part of your public API, hide it. Don't have an "internal-but-public" tier nobody can tell apart.
+
+## API-17 (MAY) — Newtype wrappers around third-party types in your public API
+
+If you expose `tokio::sync::Mutex<MyType>` directly, bumping your tokio major version is a breaking change for your users. Wrap it.
+
+## API-18 (SHOULD) — Match the standard library's vocabulary
+
+| Operation | Convention |
+| --- | --- |
+| Convert without copying | `as_*` (`as_str`, `as_bytes`) |
+| Convert by allocating  | `to_*` (`to_string`, `to_owned`) |
+| Convert by consuming   | `into_*` (`into_inner`, `into_iter`) |
+| Get reference          | `get` / `get_mut` |
+| Get or panic           | `[]` indexing |
+| Iterate by reference   | `iter()` / `iter_mut()` |
+| Iterate consuming      | `into_iter()` |
+| Length                 | `len()` (not `length()` or `size()`) |
+| Empty test             | `is_empty()` (not `len() == 0`) |
+
+Going against these conventions makes the library feel foreign. Flag mismatches.

--- a/skills/idiomatic-rust-review/references/async-and-concurrency.md
+++ b/skills/idiomatic-rust-review/references/async-and-concurrency.md
@@ -1,0 +1,195 @@
+# Async & Concurrency
+
+Sources: [Cancelling async Rust](https://sunshowers.io/posts/cancelling-async-rust/), [Async Rust can be a pleasure to work with (without Send + Sync + 'static)](https://emschwartz.me/async-rust-can-be-a-pleasure-to-work-with-without-send-sync-static/), [Why choose async/await over threads?](https://notgull.net/why-not-threads/), [Rust's Sneaky Deadlock With if let Blocks](https://brooksblog.bearblog.dev/rusts-sneaky-deadlock-with-if-let-blocks/), [Await a minute](https://docs.rs/dtolnay/0.0.3/dtolnay/macro._01__await_a_minute.html).
+
+---
+
+## ASYNC-01 (MUST) — Don't hold a `std::sync::Mutex` guard across `.await`
+
+The guard isn't `Send`, and even when it is, blocking the executor on a contended mutex defeats the purpose of async.
+
+```rust
+// BAD — guard lives across the await; type doesn't compile in multi-threaded executor,
+//       and even with single-threaded it stalls the runtime
+let guard = self.cache.lock().unwrap();
+let value = guard.get(&key).cloned();
+slow_io().await;          // ← BAD
+use_it(value);
+
+// GOOD — drop before await
+let value = {
+    let guard = self.cache.lock().unwrap();
+    guard.get(&key).cloned()
+};                        // guard dropped
+slow_io().await;
+
+// GOOD — use an async-aware mutex when you really need to hold across await
+let guard = self.cache.lock().await;   // tokio::sync::Mutex
+slow_io().await;
+```
+
+Flag this aggressively. It's the #1 source of async deadlocks.
+
+## ASYNC-02 (MUST) — Cancellation safety: every `.await` is a potential drop point
+
+When an async function is dropped at an `await`, partial work disappears. Functions that mutate shared state across awaits must be written so an early drop doesn't leave invariants broken.
+
+```rust
+// BAD — if dropped between increment and decrement, counter is wrong forever
+async fn do_work(state: &State) {
+    state.active.fetch_add(1, Ordering::Relaxed);
+    do_slow_thing().await;
+    state.active.fetch_sub(1, Ordering::Relaxed);
+}
+
+// GOOD — RAII guard handles cleanup even on cancel
+async fn do_work(state: &State) {
+    let _g = ActiveGuard::new(&state.active);
+    do_slow_thing().await;
+}  // _g dropped here, decrement runs even if .await was cancelled
+```
+
+Document cancellation behavior in rustdoc. The standard answer for "what happens if this future is cancelled" should not be "I haven't thought about it."
+
+## ASYNC-03 (SHOULD) — Don't reach for `Arc<Mutex<...>>` reflexively in async code
+
+Many "I need shared state in tasks" patterns are better expressed as:
+- A channel (`tokio::sync::mpsc`) feeding a single actor task that owns the state.
+- An `Arc<T>` of an *immutable* configuration plus per-task local state.
+- `Arc<RwLock<T>>` when reads dominate writes.
+
+```rust
+// OK — but consider channels
+let state = Arc::new(Mutex::new(State::new()));
+
+// OFTEN BETTER — actor pattern
+let (tx, mut rx) = mpsc::channel::<Cmd>(64);
+tokio::spawn(async move {
+    let mut state = State::new();
+    while let Some(cmd) = rx.recv().await { state.apply(cmd); }
+});
+```
+
+## ASYNC-04 (SHOULD) — Avoid blocking calls in async functions
+
+`std::fs::read`, `std::thread::sleep`, large CPU loops — these stall the executor. Move them to `tokio::task::spawn_blocking` or use async variants.
+
+```rust
+// BAD
+async fn load(p: PathBuf) -> io::Result<Vec<u8>> {
+    std::fs::read(p)                    // blocks the executor thread
+}
+
+// GOOD
+async fn load(p: PathBuf) -> io::Result<Vec<u8>> {
+    tokio::fs::read(p).await
+}
+
+// GOOD — for CPU work
+let result = tokio::task::spawn_blocking(|| expensive_cpu_work(input)).await?;
+```
+
+## ASYNC-05 (MUST) — Don't `.unwrap()` `JoinHandle`s without thought
+
+`spawn(...).await.unwrap()` propagates *panic* from the spawned task. That may be what you want — or it may be that the task can fail for benign reasons (cancellation, runtime shutdown). Match on `JoinError::is_panic()` / `is_cancelled()` explicitly.
+
+## ASYNC-06 (SHOULD) — Prefer `?Send` / `?Sync` bounds when the caller can choose
+
+A library that hardcodes `T: Send + Sync + 'static` on every type forces users into specific runtime models. When the constraint isn't actually needed, relax it.
+
+```rust
+// BAD — forces 'static + Send on every callback
+pub fn on_event<F: Fn() + Send + 'static>(&self, f: F) { … }
+
+// GOOD — let the caller pick the bound
+pub fn on_event<F: Fn()>(&self, f: F) { … }
+// and document which executor model is intended
+```
+
+For trait objects, prefer `Box<dyn Future<Output = T>>` over `Box<dyn Future<Output = T> + Send + 'static>` until you actually need the bound.
+
+## ASYNC-07 (SHOULD) — Use `select!` and `join!` correctly
+
+- `tokio::join!` waits for *all* futures; semantically parallel.
+- `tokio::try_join!` short-circuits on first error.
+- `tokio::select!` polls until *one* completes; the others are dropped (read: cancelled).
+
+```rust
+// GOOD — fan-out fetch
+let (a, b, c) = tokio::try_join!(fetch_a(), fetch_b(), fetch_c())?;
+
+// GOOD — timeout
+tokio::select! {
+    res = work() => res,
+    _ = tokio::time::sleep(timeout) => Err(Timeout),
+}
+```
+
+Flag `select!` arms where dropping the loser would corrupt state (see ASYNC-02).
+
+## ASYNC-08 (SHOULD) — Bound channel sizes in production code
+
+Unbounded channels (`mpsc::unbounded_channel`) hide backpressure issues. Use bounded channels and let `send` await when the consumer is slow — that's the signal.
+
+```rust
+// SUSPICIOUS in production
+let (tx, rx) = mpsc::unbounded_channel();
+
+// GOOD
+let (tx, rx) = mpsc::channel(1024);
+```
+
+## ASYNC-09 (MUST) — Don't `block_on` inside an async context
+
+Calling `Runtime::block_on` from within an async function (whether on the same runtime or nested) deadlocks or panics depending on the runtime. If you genuinely need to bridge sync and async, use `spawn_blocking` + a `oneshot` channel.
+
+## ASYNC-10 (SHOULD) — `async fn` in traits: prefer `async fn` (stable since 1.75) or `async-trait`
+
+Modern Rust supports `async fn` directly in traits. Use it unless you need dyn dispatch, in which case the `async-trait` crate is still the answer (it boxes the future).
+
+```rust
+// GOOD (Rust 1.75+)
+trait Storage {
+    async fn put(&self, k: &str, v: &[u8]) -> Result<(), Error>;
+}
+
+// GOOD (needs dyn Storage)
+#[async_trait]
+trait Storage {
+    async fn put(&self, k: &str, v: &[u8]) -> Result<(), Error>;
+}
+```
+
+## ASYNC-11 (MAY) — Don't async-everything
+
+If a function does no I/O and no awaiting, it doesn't need to be `async`. Marking it `async` only burns the caller's life on a needless `.await`.
+
+```rust
+// BAD
+async fn add(a: i32, b: i32) -> i32 { a + b }
+
+// GOOD
+fn add(a: i32, b: i32) -> i32 { a + b }
+```
+
+## ASYNC-12 (SHOULD) — Structured concurrency: prefer `JoinSet` over fire-and-forget `spawn`
+
+A bare `tokio::spawn(...)` whose `JoinHandle` is dropped is a "leak" — you can't await it, cancel it, or know when it finished. Prefer `JoinSet` or store the handles.
+
+```rust
+// FRAGILE
+for item in items { tokio::spawn(process(item)); }
+
+// BETTER
+let mut set = tokio::task::JoinSet::new();
+for item in items { set.spawn(process(item)); }
+while let Some(res) = set.join_next().await { res??; }
+```
+
+## ASYNC-13 (MUST) — `Pin` is a contract, not a suggestion
+
+Manual `Pin<&mut Self>` implementations are easy to get wrong. Reach for `pin-project-lite` / `pin-project`. If reviewing handwritten `unsafe impl Unpin`, demand a `// SAFETY:` comment explaining the pinning invariants.
+
+## ASYNC-14 (MAY) — Threads still exist
+
+Async is overkill for tasks that don't need to wait on many concurrent I/O operations. For "do CPU work in the background and return," `std::thread::spawn` + a `oneshot::channel` (or `crossbeam::channel`) is simpler than async.

--- a/skills/idiomatic-rust-review/references/documentation-and-naming.md
+++ b/skills/idiomatic-rust-review/references/documentation-and-naming.md
@@ -1,0 +1,208 @@
+# Documentation & Naming
+
+Sources: [Guide on how to write documentation for a Rust crate](https://blog.guillaume-gomez.fr/articles/2020-03-12+Guide+on+how+to+write+documentation+for+a+Rust+crate), [Teaching libraries through good documentation](https://deterministic.space/teaching-libraries.html), [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/) (C-WORD-ORDER, C-CASE, C-CRATE-DOC), [Canonical's Rust Best Practices](https://canonical.github.io/rust-best-practices/).
+
+---
+
+## DOC-01 (MUST) — Every public item gets a doc comment
+
+`pub fn`, `pub struct`, `pub enum`, `pub trait`, `pub const` — all need a `///` block. Crate-level docs go in `//!` at the top of `lib.rs`. Enforce with `#![deny(missing_docs)]` in libraries.
+
+```rust
+/// A persistent key-value store backed by `sled`.
+///
+/// `Store` is cheap to clone — it wraps an `Arc` internally.
+#[derive(Clone)]
+pub struct Store { … }
+```
+
+## DOC-02 (MUST) — Doc the first line as a single-sentence summary
+
+`cargo doc` shows only the first sentence in the index. Make it count. Start with a verb in third person ("Returns…", "Reads…", "Constructs…").
+
+```rust
+// BAD
+/// This function is for getting users from the database.
+///   ↑ "this function is for" is filler.
+pub fn get_users() -> … { … }
+
+// GOOD
+/// Returns all users registered in the database.
+pub fn get_users() -> … { … }
+```
+
+## DOC-03 (SHOULD) — `# Errors` section on every fallible public function
+
+```rust
+/// Connects to the given address with the configured TLS settings.
+///
+/// # Errors
+///
+/// Returns [`ConnectError::Tls`] if the TLS handshake fails, or
+/// [`ConnectError::Io`] if the underlying socket cannot be opened.
+pub fn connect(&self, addr: SocketAddr) -> Result<Conn, ConnectError> { … }
+```
+
+Enforced by `clippy::missing_errors_doc`.
+
+## DOC-04 (SHOULD) — `# Panics` section on anything that can panic
+
+Even if "it shouldn't in practice." If the function calls `unwrap`, `expect`, indexes a slice, or divides by a runtime value, document the panic condition.
+
+```rust
+/// Returns the median of the slice.
+///
+/// # Panics
+///
+/// Panics if `values` is empty.
+pub fn median(values: &[f64]) -> f64 { … }
+```
+
+Better: change the signature to `Option<f64>` and remove the panic. Documenting the panic is the second-best option.
+
+## DOC-05 (MUST) — `# Safety` section on every `pub unsafe fn`
+
+Non-negotiable. The safety section documents what the caller must guarantee.
+
+```rust
+/// Reads `len` bytes from the raw pointer.
+///
+/// # Safety
+///
+/// - `ptr` must be valid for reads of `len` bytes.
+/// - `ptr` must be properly aligned for `u8`.
+/// - The memory at `ptr` must not be mutated for the duration of the returned slice.
+pub unsafe fn read_raw(ptr: *const u8, len: usize) -> &'static [u8] { … }
+```
+
+Enforced by `clippy::missing_safety_doc`.
+
+## DOC-06 (SHOULD) — Include `# Examples` with working doctests
+
+Doctests are also unit tests. They catch API drift.
+
+```rust
+/// Truncates the string to at most `max` characters.
+///
+/// # Examples
+///
+/// ```
+/// # use mycrate::truncate;
+/// assert_eq!(truncate("hello, world", 5), "hello");
+/// assert_eq!(truncate("hi", 5), "hi");
+/// ```
+pub fn truncate(s: &str, max: usize) -> &str { … }
+```
+
+Use `# ` to hide setup lines that distract from the example.
+
+## DOC-07 (SHOULD) — Use intra-doc links
+
+`[`MyType`]`, `[`MyType::method`]`, `[`crate::module::Thing`]` get rendered as live links and break the build when the target moves.
+
+```rust
+/// See also [`Client::connect`] and [`ConnectError`].
+```
+
+## DOC-08 (MAY) — Crate-level `//!` doc explains the *concept*, not the API
+
+The crate root is the elevator pitch: what problem does this crate solve, what's the headline example, what's the mental model. Detailed API docs go on individual items.
+
+```rust
+//! # mycrate
+//!
+//! A small DSL for declaratively configuring HTTP clients.
+//!
+//! ```rust
+//! let client = mycrate::Client::builder()
+//!     .timeout(Duration::from_secs(5))
+//!     .build()?;
+//! ```
+//!
+//! See [`Client`] for the main entry point.
+```
+
+## DOC-09 (SHOULD) — Document non-obvious invariants and trade-offs
+
+Doc comments are not just for "what the function returns." Use them for:
+- Complexity (`O(n log n)` time, `O(1)` space).
+- Allocation behavior ("does not allocate if `Cow::Borrowed`").
+- Thread-safety ("safe to call concurrently from multiple threads").
+- Cancellation safety in async functions.
+
+## DOC-10 (MUST) — Naming: snake_case for items, CamelCase for types
+
+| Item | Convention |
+| --- | --- |
+| Modules, functions, variables, methods, fields | `snake_case` |
+| Types, traits, enum variants, type parameters | `CamelCase` |
+| Constants, statics | `SCREAMING_SNAKE_CASE` |
+| Lifetimes | `'lowercase_short` |
+| Macros | `snake_case!` |
+| Crate names | `snake_case` (avoid `-`; the crate name in `Cargo.toml` uses `-`, in code it's `_`) |
+
+`Clippy` and `rustfmt` enforce most of this; flag deviations.
+
+## DOC-11 (SHOULD) — Word order: getters drop `get_`
+
+`get_x()` is C-style. In Rust, `x()` returns a reference, `x_mut()` returns mutable, `into_x()` consumes, `set_x()` sets.
+
+```rust
+// BAD
+fn get_name(&self) -> &str { … }
+fn get_name_mut(&mut self) -> &mut String { … }
+fn set_name(&mut self, n: String) { … }
+
+// GOOD
+fn name(&self) -> &str { … }
+fn name_mut(&mut self) -> &mut String { … }
+fn set_name(&mut self, n: String) { … }
+```
+
+Exception: when "get" disambiguates (`get_or_insert`).
+
+## DOC-12 (SHOULD) — Type names: noun phrases. Trait names: capabilities or relationships
+
+```rust
+// Types
+struct HttpClient;      // GOOD — noun
+struct Connect;         // BAD  — verb
+
+// Traits
+trait Read { … }        // GOOD — capability
+trait Reader { … }      // OK   — agent noun (still common)
+trait IsConnectable { … } // BAD — predicate; prefer `Connect`
+```
+
+The standard library convention: traits that describe behavior are verbs (`Read`, `Write`, `Iterator`, `Display`). Traits that describe relationships are nouns (`AsRef`, `From`).
+
+## DOC-13 (SHOULD) — Avoid abbreviations except universally-known ones
+
+`url`, `http`, `db`, `ctx` (in narrow scopes), `cfg`, `tmp`, `id` are fine. `usr_mgr_svc` is not.
+
+```rust
+// BAD
+fn proc_evt(e: &Evt) { … }
+
+// GOOD
+fn process_event(event: &Event) { … }
+```
+
+## DOC-14 (MAY) — Use `_unused` prefix, not just `_`, when the variable has meaning
+
+```rust
+// OK in a closure with no body
+let _ = items.iter().for_each(|_| {});
+
+// BAD — loses information
+fn handle(_: Request) { … }
+
+// GOOD
+fn handle(_request: Request) { … }
+```
+
+The `_request` name still shows up in error messages and IDE help.
+
+## DOC-15 (SHOULD) — README + `cargo doc` should agree
+
+The README often duplicates the crate-root doc. Either share it (with `#![doc = include_str!("../README.md")]`) or accept the maintenance cost and keep them in sync.

--- a/skills/idiomatic-rust-review/references/error-handling.md
+++ b/skills/idiomatic-rust-review/references/error-handling.md
@@ -1,0 +1,208 @@
+# Error Handling
+
+Sources: [Error Handling in Rust (BurntSushi)](https://burntsushi.net/rust-error-handling/), [Context-preserving error handling](https://kazlauskas.me/entries/errors), [Designing Error Types in Rust Libraries](https://d34dl0ck.me/rust-bites-designing-error-types-in-rust-libraries/), [To panic or not to panic](https://www.ncameron.org/blog/to-panic-or-not-to-panic/), [Three Kinds Of Unwrap](https://zkrising.com/writing/three-unwraps/), [Practical guide to Error Handling in Rust](https://dev-state.com/posts/error_handling/), [Wrapping errors in Rust](https://edgl.dev/blog/wrapping-errors-in-rust/), Rust API Guidelines.
+
+---
+
+## ERR-01 (MUST) — `Result<T, E>` for recoverable errors, `panic!` for bugs
+
+A panic means "this should be impossible — fix the program." A `Result::Err` means "this can happen at runtime and the caller should decide." Anything that depends on user input, the filesystem, the network, or untrusted data is `Result`.
+
+```rust
+// BAD — a malformed config file kills the process
+let port: u16 = config_str.parse().unwrap();
+
+// GOOD
+let port: u16 = config_str.parse()
+    .map_err(|e| ConfigError::InvalidPort { value: config_str.into(), source: e })?;
+```
+
+## ERR-02 (MUST) — No `unwrap` / `expect` on fallible operations in library code
+
+A library that panics on input it disagrees with is broken. The exceptions:
+
+1. **Tests, examples, benchmarks** — fine.
+2. **Compile-time guarantees the type system can't see** — use `.expect("invariant: ...")` and document the invariant in the message.
+3. **`main()` in a binary** — prefer returning `Result` so the runtime error formatting kicks in.
+
+```rust
+// BAD — panic exposed in a library
+pub fn parse_packet(bytes: &[u8]) -> Packet {
+    Packet { kind: bytes[0], len: bytes[1] }  // panics on short input
+}
+
+// GOOD
+pub fn parse_packet(bytes: &[u8]) -> Result<Packet, ParseError> {
+    let kind = *bytes.first().ok_or(ParseError::Truncated)?;
+    let len  = *bytes.get(1).ok_or(ParseError::Truncated)?;
+    Ok(Packet { kind, len })
+}
+```
+
+## ERR-03 (MUST) — Use `?` to propagate, not `match … return Err(e)`
+
+```rust
+// BAD
+let bytes = match read_file(p) {
+    Ok(b) => b,
+    Err(e) => return Err(e.into()),
+};
+
+// GOOD
+let bytes = read_file(p)?;
+```
+
+`?` calls `From::from` on the error, so a single `#[from]` in your error enum makes propagation transparent.
+
+## ERR-04 (SHOULD) — Library errors: enum with `thiserror`
+
+Callers must be able to *match on* what went wrong. Use a concrete enum, derive `thiserror::Error`, and chain causes with `#[source]`.
+
+```rust
+// GOOD
+#[derive(Debug, thiserror::Error)]
+pub enum LoadError {
+    #[error("config file not found at {path}")]
+    NotFound { path: PathBuf },
+
+    #[error("config file is malformed")]
+    Parse(#[from] toml::de::Error),
+
+    #[error("I/O error reading {path}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+```
+
+Anti-patterns to flag:
+
+- `pub fn ... -> Result<T, Box<dyn Error>>` in a library — opaque.
+- `pub fn ... -> anyhow::Result<T>` in a library — same problem, just nicer ergonomics for the wrong audience.
+- A single mega-enum `Error { Other(String) }` — callers can't distinguish failure modes.
+
+## ERR-05 (SHOULD) — Application errors: `anyhow` (or `eyre`) with `.context()`
+
+In a binary, you typically log the error and exit. `anyhow` makes that fluent:
+
+```rust
+use anyhow::{Context, Result};
+
+fn run() -> Result<()> {
+    let cfg = load_config(&path)
+        .with_context(|| format!("loading config from {}", path.display()))?;
+    let server = Server::bind(cfg.addr)
+        .context("binding server")?;
+    server.run().context("serving requests")?;
+    Ok(())
+}
+```
+
+Every `?` boundary is an opportunity for `.context()`. Bare `?` with no context yields error chains that read like "I/O error: I/O error: not found" — useless.
+
+## ERR-06 (SHOULD) — Don't swallow errors with `.ok()` or `let _ =`
+
+```rust
+// BAD — error silently discarded
+let _ = file.flush();
+
+// GOOD — make the choice explicit and audited
+if let Err(e) = file.flush() {
+    tracing::warn!(?e, "flush failed; data may be lost");
+}
+```
+
+The only legitimate `let _ = ...` is when the function returns `Result` purely for compatibility (e.g., `writeln!` to a `String` that can't fail) and you genuinely don't care.
+
+## ERR-07 (SHOULD) — `Option::ok_or_else` over `ok_or` when the error allocates
+
+`ok_or(e)` evaluates `e` eagerly even when the `Option` is `Some`.
+
+```rust
+// BAD — formats the string every call, even when found
+map.get(&k).ok_or(format!("key not found: {k}"))?;
+
+// GOOD
+map.get(&k).ok_or_else(|| format!("key not found: {k}"))?;
+```
+
+Same applies to `unwrap_or` vs `unwrap_or_else`, and to `.map_err(|e| heavy(e))` vs cheap closures.
+
+## ERR-08 (MAY) — `Result<T, E>` is more idiomatic than `Option<T>` for "this might fail with a reason"
+
+Use `Option<T>` for "this value is sometimes absent and that's normal" (lookup, parsing optional fields). Use `Result<T, E>` when there's a *reason* for the absence the caller might want to inspect or log.
+
+```rust
+// Marginal — caller has no idea why
+fn find_user(id: UserId) -> Option<User> { … }
+
+// Better when "not found" is one of several outcomes
+fn load_user(id: UserId) -> Result<User, LoadError> { … }
+```
+
+## ERR-09 (SHOULD) — Document `# Errors` and `# Panics` in rustdoc
+
+Every public fallible function should have an `# Errors` section. Every function that *can* panic — even if "shouldn't in practice" — needs `# Panics`.
+
+```rust
+/// Reads the entire file as UTF-8.
+///
+/// # Errors
+///
+/// Returns [`LoadError::Io`] if the file cannot be opened, or
+/// [`LoadError::Parse`] if the contents are not valid UTF-8.
+///
+/// # Panics
+///
+/// Panics if `path` contains an interior NUL byte.
+pub fn load(path: impl AsRef<Path>) -> Result<String, LoadError> { … }
+```
+
+`clippy::missing_errors_doc` and `clippy::missing_panics_doc` enforce this.
+
+## ERR-10 (MUST) — Panic-safety in `unsafe` and `Drop`
+
+A panic that unwinds across an FFI boundary is UB. A panic in a `Drop` impl while already unwinding aborts the program. Flag any `unsafe extern "C" fn` that doesn't either `catch_unwind` or use `#[unwind(abort)]`-equivalent settings, and any `Drop` that calls fallible code without handling panics.
+
+## ERR-11 (MAY) — Avoid `.unwrap_or_default()` when it hides bugs
+
+`u64::default()` is `0`. `String::default()` is `""`. If `0` or `""` is a valid value that means "absent," that's fine. If a `0` would silently corrupt the calculation, prefer to surface the error.
+
+## ERR-12 (SHOULD) — `From` impls for error conversions, not manual `.map_err`
+
+```rust
+// VERBOSE
+fn load() -> Result<Cfg, LoadError> {
+    let s = std::fs::read_to_string(p).map_err(LoadError::Io)?;
+    let c: Cfg = toml::from_str(&s).map_err(LoadError::Parse)?;
+    Ok(c)
+}
+
+// IDIOMATIC — let `?` do the conversion
+#[derive(thiserror::Error, Debug)]
+enum LoadError {
+    #[error(transparent)] Io(#[from] std::io::Error),
+    #[error(transparent)] Parse(#[from] toml::de::Error),
+}
+
+fn load(p: &Path) -> Result<Cfg, LoadError> {
+    let s = std::fs::read_to_string(p)?;
+    let c: Cfg = toml::from_str(&s)?;
+    Ok(c)
+}
+```
+
+Caveat: when context matters (which file? which line?), keep the explicit `.map_err` to attach it.
+
+## Quick reference: when to use what
+
+| Situation | Choice |
+| --- | --- |
+| Bug, broken invariant | `panic!` / `unreachable!` / `debug_assert!` |
+| Recoverable failure, caller wants to match | `Result<T, MyError>` (enum) |
+| Recoverable failure, caller just logs | `anyhow::Result<T>` |
+| Optional value, no reason needed | `Option<T>` |
+| Compile-time-known impossibility | `.expect("explain why")` |
+| Test or example | `.unwrap()` is fine |

--- a/skills/idiomatic-rust-review/references/example-review.md
+++ b/skills/idiomatic-rust-review/references/example-review.md
@@ -1,0 +1,239 @@
+# Example: A Worked Review
+
+Showing what an AI reviewer using this skill produces. The input is a small Rust function; the output applies the rules above.
+
+---
+
+## Input
+
+```rust
+// from src/cache.rs
+use std::sync::{Arc, Mutex};
+use std::collections::HashMap;
+
+pub struct Cache {
+    inner: Arc<Mutex<HashMap<String, String>>>,
+}
+
+impl Cache {
+    pub fn new() -> Cache {
+        Cache { inner: Arc::new(Mutex::new(HashMap::new())) }
+    }
+
+    pub fn get(&self, k: String) -> String {
+        let map = self.inner.lock().unwrap();
+        let v = map.get(&k).unwrap();
+        return v.clone();
+    }
+
+    pub fn put(self, k: String, v: String, overwrite: bool) -> bool {
+        let mut map = self.inner.lock().unwrap();
+        if map.contains_key(&k) == true && overwrite == false {
+            return false;
+        }
+        map.insert(k, v);
+        return true;
+    }
+}
+```
+
+---
+
+## Reviewer output
+
+### Summary
+
+The cache works but has several idiomatic issues: it panics on missing keys, takes owned `String`s where `&str` would do, uses a boolean parameter that should be an enum, and has style issues (`== true`, trailing `return`, `&Vec`-style ownership). Also missing `Default`, `Debug`, and any documentation.
+
+### MUST
+
+**[R-1 / ERR-02] cache.rs:14 — `.unwrap()` panic on missing key**
+
+```rust
+let v = map.get(&k).unwrap();   // panics if key absent
+```
+
+A cache `get` should return `Option<String>`, not panic when the value isn't there. Cache misses are the *whole point* of caches.
+
+```rust
+pub fn get(&self, k: &str) -> Option<String> {
+    let map = self.inner.lock().unwrap();
+    map.get(k).cloned()
+}
+```
+
+Source: [Three Kinds Of Unwrap](https://zkrising.com/writing/three-unwraps/).
+
+**[API-01 / DOC-01] cache.rs:5 — `Cache` is missing `Debug` and any documentation**
+
+```rust
+/// An in-memory string cache, cheaply clonable.
+#[derive(Clone, Debug, Default)]
+pub struct Cache { … }
+```
+
+(Manual `Debug` if you don't want to leak entries.)
+
+**[ANTI-21] cache.rs:21–22 — `== true` / `== false` against booleans**
+
+```rust
+if map.contains_key(&k) == true && overwrite == false { … }
+
+// →
+if map.contains_key(&k) && !overwrite { … }
+```
+
+Caught by `clippy::bool_comparison`.
+
+### SHOULD
+
+**[R-2 / TYPE-03 / OWN-10] cache.rs:13, cache.rs:18 — Owned `String` arguments**
+
+`get(&self, k: String)` forces every caller to allocate. `put(self, k: String, v: String, ...)` is fine for `v` (you'll store it) but the cache shouldn't be consumed.
+
+```rust
+pub fn get(&self, k: &str) -> Option<String> { … }
+pub fn put(&self, k: impl Into<String>, v: impl Into<String>, mode: WriteMode) -> bool { … }
+```
+
+Source: [Taking string arguments in Rust](http://xion.io/post/code/rust-string-args.html).
+
+**[OWN-04] cache.rs:18 — `put` takes `self` by value**
+
+You almost certainly meant `&self`. As written, calling `put` consumes the cache.
+
+```rust
+pub fn put(&self, k: String, v: String, mode: WriteMode) -> bool { … }
+```
+
+**[R-3 / TYPE-02] cache.rs:18 — Boolean `overwrite` parameter**
+
+`overwrite: bool` doesn't read well at call sites: `cache.put(k, v, true)` — true what? Replace with an enum.
+
+```rust
+pub enum WriteMode { Insert, Overwrite }
+
+pub fn put(&self, k: String, v: String, mode: WriteMode) -> bool { … }
+
+// call sites become:
+cache.put(k, v, WriteMode::Overwrite);
+```
+
+Source: [Rust Patterns: Enums Instead Of Booleans](https://blakesmith.me/2019/05/07/rust-patterns-enums-instead-of-booleans.html).
+
+**[ITER-11] cache.rs:21–24 — `contains_key` + `insert` is two lookups**
+
+```rust
+if map.contains_key(&k) && overwrite == false { return false; }
+map.insert(k, v);
+
+// →
+match map.entry(k) {
+    Entry::Occupied(_) if matches!(mode, WriteMode::Insert) => return false,
+    Entry::Occupied(mut e) => { e.insert(v); }
+    Entry::Vacant(e) => { e.insert(v); }
+}
+```
+
+One hash lookup instead of two. Caught by `clippy::map_entry`.
+
+**[R-10 / OWN-11] cache.rs:13–15 — Lock guard held longer than needed**
+
+Minor here, but a habit to build: scope the guard to the smallest region.
+
+```rust
+pub fn get(&self, k: &str) -> Option<String> {
+    let map = self.inner.lock().unwrap();
+    map.get(k).cloned()                 // guard dropped on return
+}
+```
+
+(In this case it's already fine because the function ends; flagging the pattern for future methods.)
+
+### MAY
+
+**[ANTI-19] cache.rs:16, cache.rs:23, cache.rs:26 — Trailing `return` at end of function**
+
+```rust
+return v.clone();   // → v.clone()
+return false;       // → false (when last expression of an arm)
+return true;        // → true
+```
+
+**[API-13] cache.rs — Missing `Default`**
+
+`Cache::new()` takes no args, so `impl Default` is a one-liner that lets `Cache` work in generic `Default` contexts and lets users write `Cache::default()`.
+
+```rust
+impl Default for Cache {
+    fn default() -> Self { Self::new() }
+}
+```
+
+Or derive `Default` directly:
+
+```rust
+#[derive(Clone, Default)]
+pub struct Cache { inner: Arc<Mutex<HashMap<String, String>>> }
+```
+
+### Strengths
+
+- Wrapping the `HashMap` in `Arc<Mutex<…>>` and *not* exposing it is the right call — callers see `Cache`, not raw locking primitives.
+- Using `Arc` makes `Cache` cheaply cloneable so handles can be passed to multiple tasks.
+- Method signatures are short and the type takes a focused responsibility.
+
+---
+
+## Putting it all together
+
+```rust
+//! A small in-memory string cache.
+
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+use std::sync::{Arc, Mutex};
+
+/// Controls whether `put` replaces an existing entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteMode {
+    /// Only insert if the key is absent.
+    Insert,
+    /// Always insert, replacing any existing entry.
+    Overwrite,
+}
+
+/// An in-memory string cache. Cheap to clone — handles share the underlying map.
+#[derive(Clone, Default)]
+pub struct Cache {
+    inner: Arc<Mutex<HashMap<String, String>>>,
+}
+
+impl Cache {
+    /// Returns a new, empty cache.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns a copy of the value for `key`, if present.
+    pub fn get(&self, key: &str) -> Option<String> {
+        let map = self.inner.lock().expect("cache mutex poisoned");
+        map.get(key).cloned()
+    }
+
+    /// Inserts `value` under `key`.
+    ///
+    /// Returns `true` if the cache was modified. In [`WriteMode::Insert`] mode,
+    /// returns `false` if the key already exists.
+    pub fn put(&self, key: impl Into<String>, value: impl Into<String>, mode: WriteMode) -> bool {
+        let mut map = self.inner.lock().expect("cache mutex poisoned");
+        match map.entry(key.into()) {
+            Entry::Occupied(_) if mode == WriteMode::Insert => false,
+            Entry::Occupied(mut e) => { e.insert(value.into()); true }
+            Entry::Vacant(e)       => { e.insert(value.into()); true }
+        }
+    }
+}
+```
+
+That's the difference between "compiles" and "idiomatic." Every change cites a specific source from the corpus.

--- a/skills/idiomatic-rust-review/references/iterators-and-collections.md
+++ b/skills/idiomatic-rust-review/references/iterators-and-collections.md
@@ -1,0 +1,199 @@
+# Iterators & Collections
+
+Sources: [Effectively Using Iterators In Rust](https://hermanradtke.com/2015/06/22/effectively-using-iterators-in-rust.html/), [Rust Iterators Beyond the Basics](https://blog.jetbrains.com/rust/2024/03/12/rust-iterators-beyond-the-basics-part-i-building-blocks/), [Iteration patterns for Result & Option](http://xion.io/post/code/rust-iter-patterns.html), [Russian Dolls and clean Rust code](https://web.archive.org/web/20220126183049/https://blog.mgattozzi.dev/russian-dolls/), [Rayon: data parallelism in Rust](https://smallcultfollowing.com/babysteps/blog/2015/12/18/rayon-data-parallelism-in-rust/).
+
+---
+
+## ITER-01 (SHOULD) — Prefer iterator chains over index loops
+
+```rust
+// BAD
+let mut out = Vec::new();
+for i in 0..items.len() {
+    if items[i].active { out.push(items[i].name.clone()); }
+}
+
+// GOOD
+let out: Vec<String> = items.iter()
+    .filter(|i| i.active)
+    .map(|i| i.name.clone())
+    .collect();
+```
+
+The iterator form is allocation-aware (`collect` can size-hint), composes with `rayon` for parallelism, and reads top-to-bottom as a pipeline.
+
+Counter-rule: when the body has multiple early returns, side-effects, or interleaved state, a `for` loop is clearer. Don't force a `.fold()` for the sake of it.
+
+## ITER-02 (MUST) — `collect::<Result<Vec<_>, _>>()` to short-circuit on first error
+
+```rust
+// BAD — partial results, error swallowed
+let parsed: Vec<i32> = strs.iter().map(|s| s.parse().unwrap()).collect();
+
+// GOOD — first error propagates
+let parsed: Vec<i32> = strs.iter().map(|s| s.parse()).collect::<Result<_, _>>()?;
+```
+
+Same trick works for `Option`: `iter.map(...).collect::<Option<Vec<_>>>()`.
+
+## ITER-03 (SHOULD) — `flat_map` instead of `map(...).flatten()`
+
+```rust
+// BAD
+words.iter().map(|w| w.chars()).flatten()
+
+// GOOD
+words.iter().flat_map(|w| w.chars())
+```
+
+Same number of allocations, one fewer combinator, signals intent.
+
+## ITER-04 (SHOULD) — Use `iter()` / `iter_mut()` / `into_iter()` deliberately
+
+These have different semantics; pick the one you need:
+
+- `iter()` → `&T` — caller keeps the collection.
+- `iter_mut()` → `&mut T` — caller keeps the collection, mutates in place.
+- `into_iter()` → `T` — consumes the collection.
+
+```rust
+// BAD — into_iter consumes when we only needed to read
+for item in &vec { … }            // borrows
+for item in vec.into_iter() { … } // consumes, vec is gone
+```
+
+`for x in vec` calls `into_iter()` implicitly. `for x in &vec` calls `iter()`. Know the difference.
+
+## ITER-05 (SHOULD) — Don't `collect()` then iterate again
+
+Every `collect()` allocates. If you only need to iterate, stay lazy.
+
+```rust
+// BAD
+let v: Vec<_> = items.iter().filter(|i| i.active).collect();
+for item in v { use_it(item); }
+
+// GOOD
+for item in items.iter().filter(|i| i.active) { use_it(item); }
+```
+
+The collection is justified when you'll iterate multiple times, sort, index, or send across a thread boundary.
+
+## ITER-06 (MAY) — Prefer `.sum()` / `.product()` / `.min()` / `.max()` over manual fold
+
+```rust
+// BAD
+let total = nums.iter().fold(0, |a, b| a + b);
+
+// GOOD
+let total: i64 = nums.iter().sum();
+```
+
+Reach for `fold` when the accumulator isn't a primitive numeric reduction.
+
+## ITER-07 (SHOULD) — `partition` for splitting into two collections
+
+```rust
+// BAD
+let mut passed = Vec::new();
+let mut failed = Vec::new();
+for r in results { if r.ok { passed.push(r); } else { failed.push(r); } }
+
+// GOOD
+let (passed, failed): (Vec<_>, Vec<_>) = results.into_iter().partition(|r| r.ok);
+```
+
+## ITER-08 (SHOULD) — `try_fold` / `try_for_each` for fallible reductions
+
+```rust
+// IDIOMATIC
+let total = nums.iter().try_fold(0i64, |acc, &n| acc.checked_add(n).ok_or(Overflow))?;
+```
+
+## ITER-09 (MUST) — Don't index into iterators with `.nth()` in loops
+
+`.nth(i)` consumes `i+1` items every call. In a loop you've made the iteration O(n²).
+
+```rust
+// BAD
+for i in 0..n {
+    let x = my_iter.clone().nth(i).unwrap();
+    use_it(x);
+}
+
+// GOOD
+for x in my_iter { use_it(x); }
+```
+
+If you genuinely need indexed access, collect to a `Vec` once.
+
+## ITER-10 (SHOULD) — `Vec::with_capacity` when the size is known
+
+```rust
+// OK
+let mut v = Vec::new();
+for x in 0..1000 { v.push(transform(x)); }
+
+// BETTER
+let mut v = Vec::with_capacity(1000);
+for x in 0..1000 { v.push(transform(x)); }
+
+// BEST
+let v: Vec<_> = (0..1000).map(transform).collect();  // collect uses size_hint
+```
+
+## ITER-11 (MAY) — `HashMap::entry` for "insert-or-update"
+
+```rust
+// BAD
+if let Some(v) = map.get_mut(&k) {
+    v.push(item);
+} else {
+    map.insert(k, vec![item]);
+}
+
+// GOOD
+map.entry(k).or_default().push(item);
+```
+
+## ITER-12 (SHOULD) — Match container choice to access pattern
+
+| Need | Container |
+| --- | --- |
+| Ordered, indexed, push/pop at end | `Vec<T>` |
+| Push/pop at both ends | `VecDeque<T>` |
+| Stable iteration, dedup | `BTreeSet<T>` |
+| Fast lookup, no order | `HashSet<T>` |
+| Insertion-ordered map | `IndexMap` (crate) |
+| LRU cache | `lru` (crate) |
+| Sparse integer keys | `BTreeMap<usize, T>` or `slotmap` |
+
+Flag uses of `Vec::contains` in hot paths — that's an O(n) linear scan; a `HashSet` is O(1).
+
+## ITER-13 (SHOULD) — Use `windows` / `chunks` / `chunks_exact` over manual indexing
+
+```rust
+// BAD
+for i in 1..v.len() {
+    let prev = v[i - 1];
+    let cur = v[i];
+    process_pair(prev, cur);
+}
+
+// GOOD
+for pair in v.windows(2) {
+    process_pair(pair[0], pair[1]);
+}
+```
+
+## ITER-14 (MAY) — `zip` + `enumerate` order: `.iter().enumerate()` reads better than `.enumerate().iter()`
+
+`enumerate()` adds `(usize, T)` tuples. Place it where it composes naturally:
+
+```rust
+for (i, (a, b)) in xs.iter().zip(ys.iter()).enumerate() { … }
+```
+
+## ITER-15 (MAY) — `rayon`'s `par_iter` for embarrassingly parallel work
+
+When the work per item is non-trivial (file parse, CPU-bound transform), changing `.iter()` to `.par_iter()` often gives a free speedup. Don't suggest it for IO-bound or tiny-work loops where the overhead dominates.

--- a/skills/idiomatic-rust-review/references/ownership-and-lifetimes.md
+++ b/skills/idiomatic-rust-review/references/ownership-and-lifetimes.md
@@ -1,0 +1,180 @@
+# Ownership & Lifetimes
+
+Sources: [Don't Worry About Lifetimes](https://corrode.dev/blog/lifetimes/), [Strategies for solving 'cannot move out of' borrowing errors in Rust](https://hermanradtke.com/2015/06/09/strategies-for-solving-cannot-move-out-of-borrowing-errors-in-rust.html/), [Naming Your Lifetimes](https://www.possiblerust.com/pattern/naming-your-lifetimes), [Aim For Immutability in Rust](https://corrode.dev/blog/immutability/), [When should I use String vs &str?](https://steveklabnik.com/writing/when-should-i-use-string-vs-str/), Rust API Guidelines.
+
+---
+
+## OWN-01 (MUST) — Don't `.clone()` away every borrow-checker error
+
+Reflexive cloning is the #1 sign of a Rust-by-translation codebase. Most "cannot move out of" / "borrowed value does not live long enough" errors have a structural fix:
+
+| Symptom | Often-better fix |
+| --- | --- |
+| Can't move out of `&self`. | Take `self` by value, or return references with the right lifetime, or split the struct. |
+| Multiple mutable borrows of fields. | Use `split_at_mut`, destructure, or restructure the struct. |
+| Closure outlives function. | Take `'static` data, use `Arc`, or change ownership direction. |
+| Iterator yields `&T`, caller needs `T`. | Pass ownership of the source, or use `into_iter()`. |
+
+```rust
+// BAD — clones every element just to placate the borrow checker
+let names: Vec<String> = users.iter().map(|u| u.name.clone()).collect();
+
+// GOOD — if you'll consume `users` anyway, take ownership
+let names: Vec<String> = users.into_iter().map(|u| u.name).collect();
+
+// GOOD — if you need both, separate the read from the consume
+let names: Vec<&str> = users.iter().map(|u| u.name.as_str()).collect();
+```
+
+`.clone()` is sometimes the right answer — for small `Copy`-able types it's free, and for cheaply-cloneable types like `Arc<T>` it's idiomatic. The rule is: each `.clone()` should be a *deliberate* choice, not a panic-button.
+
+## OWN-02 (MUST) — `Rc<RefCell<T>>` / `Arc<Mutex<T>>` is a code smell unless justified
+
+These types exist for shared mutable state. If the structure can be expressed with normal `&` / `&mut` borrows, do that instead. Common refactors:
+
+- A struct that "needs" `RefCell` to satisfy a callback often just needs `&mut self` plumbed through.
+- A graph "needs" `Rc<RefCell<Node>>` only if you accept the interior-mutability tax — arena allocation (`generational_arena`, `slotmap`, indices into `Vec`) is usually cleaner and faster.
+
+Flag any `Rc<RefCell<…>>` in new code and ask: "what does this enable that ownership can't?"
+
+## OWN-03 (SHOULD) — Borrow inputs, own outputs
+
+Default function signature mental model:
+
+```rust
+fn process(input: &Input) -> Output { … }
+```
+
+Borrow what you read, return what the caller will keep. Reach for `&mut self` / `&mut T` only when you genuinely need to modify in place.
+
+## OWN-04 (SHOULD) — Take `self` by value to consume
+
+If a method's purpose is to finalize, build, or transform an object so the old form is meaningless, take `self` by value. This is the **builder finalize** pattern.
+
+```rust
+// BAD — caller could try to .build() twice and get inconsistent state
+impl RequestBuilder {
+    pub fn build(&self) -> Request { Request { … } }
+}
+
+// GOOD
+impl RequestBuilder {
+    pub fn build(self) -> Request { Request { … } }
+}
+```
+
+## OWN-05 (SHOULD) — Elide lifetimes when the compiler can infer them
+
+Rust's elision rules cover the vast majority of single-input/single-output cases. Don't write what the compiler will write for you.
+
+```rust
+// BAD — noise
+fn first_word<'a>(s: &'a str) -> &'a str { … }
+
+// GOOD — elided
+fn first_word(s: &str) -> &str { … }
+```
+
+## OWN-06 (SHOULD) — Name lifetimes descriptively in complex signatures
+
+When elision *can't* handle it, `'a` and `'b` are uninformative. Name the lifetime after what it refers to.
+
+```rust
+// BAD
+fn merge<'a, 'b>(left: &'a Map, right: &'b Map) -> Iterator<…> { … }
+
+// GOOD
+fn merge<'left, 'right>(left: &'left Map, right: &'right Map) -> Iterator<…> { … }
+
+// EVEN BETTER — does it really need two lifetimes?
+fn merge<'a>(left: &'a Map, right: &'a Map) -> Iterator<…> { … }
+```
+
+## OWN-07 (SHOULD) — `'static` bounds are a design choice, not a default
+
+A `'static` bound on a generic parameter forces the caller's value to live forever (or be owned). It's required for threads and many async runtimes. Outside those cases, prefer relaxed bounds.
+
+```rust
+// BAD — forces every caller to pass a fully-owned type
+fn handle<T: 'static>(value: T) { … }
+
+// GOOD — accept anything that lives long enough
+fn handle<'a, T: 'a>(value: T) { … }
+```
+
+## OWN-08 (SHOULD) — Don't return references to local data
+
+The compiler will catch this, but reviewers often see attempts that "almost work" with leaking or `Box::leak`. If you need to return owned data, just say so.
+
+```rust
+// BAD — Box::leak to satisfy a &'static signature is almost always wrong
+fn name() -> &'static str { Box::leak(format!("{}", x).into_boxed_str()) }
+
+// GOOD
+fn name() -> String { format!("{}", x) }
+```
+
+## OWN-09 (MAY) — `let mut` should be the exception
+
+After writing a function, scan for `let mut`. Each one is a small opportunity to rewrite as a `match`, iterator chain, or `if`-expression that produces the final value directly. The goal isn't purism — it's that single-assignment code is easier to refactor and reason about.
+
+```rust
+// OK
+let mut total = 0;
+for x in xs { if x > 0 { total += x; } }
+
+// BETTER
+let total: i64 = xs.iter().filter(|&&x| x > 0).sum();
+```
+
+## OWN-10 (SHOULD) — Use `&[T]` slices, not `&Vec<T>`
+
+Taking `&Vec<T>` is strictly less flexible than `&[T]`. The compiler will warn (`clippy::ptr_arg`).
+
+```rust
+// BAD
+fn first(v: &Vec<i32>) -> Option<&i32> { v.first() }
+
+// GOOD
+fn first(v: &[i32]) -> Option<&i32> { v.first() }
+```
+
+Same goes for `&String` → `&str` and `&PathBuf` → `&Path`.
+
+## OWN-11 (SHOULD) — Drop temporaries explicitly when scope matters
+
+`MutexGuard`s, `RwLockReadGuard`s, and similar RAII types release on drop. The drop point is the end of the enclosing block — not the end of the statement.
+
+```rust
+// BAD — guard held across the await; can deadlock or hurt throughput
+let guard = mutex.lock().await;
+let value = guard.compute();
+some_async_work().await;
+use_it(value);
+
+// GOOD — release before await
+let value = {
+    let guard = mutex.lock().await;
+    guard.compute()
+};                // guard dropped here
+some_async_work().await;
+use_it(value);
+```
+
+## OWN-12 (MAY) — Use `Cow<'_, T>` when sometimes-borrowed, sometimes-owned
+
+`Cow` (clone-on-write) is for APIs that return the input unchanged when possible and only allocate on modification. Don't over-use — it adds a layer to every access.
+
+```rust
+fn trim_prefix<'a>(s: &'a str, prefix: &str) -> Cow<'a, str> {
+    s.strip_prefix(prefix).map(Cow::Borrowed).unwrap_or(Cow::Borrowed(s))
+}
+```
+
+## OWN-13 (SHOULD) — Self-referential structs are a smell
+
+If you find yourself wanting a struct that holds both a `String` and a `&str` pointing into it, you need either a different design (store indices instead of references) or a crate like `ouroboros` / `self_cell`. Plain Rust can't express this safely.
+
+## OWN-14 (MAY) — Prefer `&self` over `&mut self` over `self` in trait methods
+
+For ergonomics: a `&self` method can be called on `Arc<T>`, in a shared context, behind a mutex guard. `&mut self` and `self` lock in stricter usage. This is a design choice, not a hard rule — sometimes you genuinely need `&mut self`.

--- a/skills/idiomatic-rust-review/references/pattern-matching.md
+++ b/skills/idiomatic-rust-review/references/pattern-matching.md
@@ -1,0 +1,191 @@
+# Pattern Matching
+
+Sources: [Level Up your Rust pattern matching](https://blog.cuongle.dev/p/level-up-your-rust-pattern-matching), [Rust's Sneaky Deadlock With if let Blocks](https://brooksblog.bearblog.dev/rusts-sneaky-deadlock-with-if-let-blocks/), [Russian Dolls and clean Rust code](https://web.archive.org/web/20220126183049/https://blog.mgattozzi.dev/russian-dolls/), [Pretty State Machine Patterns in Rust](https://hoverbear.org/2016/10/12/rust-state-machine-pattern/), [Iteration patterns for Result & Option](http://xion.io/post/code/rust-iter-patterns.html).
+
+---
+
+## MATCH-01 (MUST) — Don't write wildcard arms on closed enums you control
+
+Wildcard arms silently absorb new variants when the enum grows. For an enum you own, list every variant — the compiler tells you when something new needs handling.
+
+```rust
+// BAD — adding `Event::Reconnected` later silently routes to the wildcard
+match event {
+    Event::Connected => connect(),
+    Event::Disconnected => disconnect(),
+    _ => {},
+}
+
+// GOOD
+match event {
+    Event::Connected => connect(),
+    Event::Disconnected => disconnect(),
+    Event::MessageReceived(_) => {},
+}
+```
+
+For `#[non_exhaustive]` foreign enums, a wildcard is required.
+
+## MATCH-02 (SHOULD) — `if let` for one variant, `match` for two or more
+
+```rust
+// BAD
+match maybe { Some(x) => use_it(x), None => {} }
+
+// GOOD
+if let Some(x) = maybe { use_it(x); }
+```
+
+For three variants of one enum, `match` reads better than chained `if let else if let`.
+
+## MATCH-03 (SHOULD) — `let-else` for early return on `None` / `Err`
+
+```rust
+// VERBOSE
+let value = match get_value() {
+    Some(v) => v,
+    None => return,
+};
+
+// IDIOMATIC
+let Some(value) = get_value() else { return };
+```
+
+Stable since 1.65. Replaces the "match, return on None, otherwise bind" boilerplate.
+
+## MATCH-04 (SHOULD) — `matches!` for boolean checks
+
+```rust
+// VERBOSE
+let is_ready = match state { State::Ready | State::Idle => true, _ => false };
+
+// IDIOMATIC
+let is_ready = matches!(state, State::Ready | State::Idle);
+```
+
+## MATCH-05 (MUST) — Pattern temporaries live until the end of the `if let` block
+
+The lifetime trap: in `if let Some(x) = mutex.lock().get(&k)`, the lock guard is the temporary, and it lives for the *entire body* of the `if let`. This is why `if let` chains can deadlock with mutexes and hold borrows longer than expected.
+
+```rust
+// BAD — lock held for the whole branch
+if let Some(value) = self.cache.lock().get(&key).cloned() {
+    expensive(value);   // lock still held
+}
+
+// GOOD — bind explicitly, scope-control the temporary
+let cached = self.cache.lock().get(&key).cloned();
+if let Some(value) = cached { expensive(value); }
+```
+
+The same trap applies to `match` scrutinees and `while let`.
+
+## MATCH-06 (SHOULD) — Use binding `@` patterns to capture and check together
+
+```rust
+// VERBOSE
+match n {
+    n if n < 0 => negative(n),
+    n if n > 100 => big(n),
+    n => normal(n),
+}
+
+// IDIOMATIC
+match n {
+    x @ ..0    => negative(x),
+    x @ 101..  => big(x),
+    x          => normal(x),
+}
+```
+
+## MATCH-07 (SHOULD) — Destructure in function parameters when it helps
+
+```rust
+// OK
+fn area(p: Point) -> f64 { p.x * p.y }
+
+// CLEANER WHEN THE POINT FIELDS ARE THE WHOLE STORY
+fn area(Point { x, y }: Point) -> f64 { x * y }
+```
+
+Don't overuse — when the struct name carries information ("this is a `Point`, not just coordinates"), keep it named.
+
+## MATCH-08 (SHOULD) — Combine arms with `|` instead of duplicating bodies
+
+```rust
+// BAD
+match c {
+    'a' | 'e' | 'i' | 'o' | 'u' => …,
+    'A' => vowel(),
+    'E' => vowel(),
+    'I' => vowel(),
+    _ => consonant(),
+}
+
+// GOOD
+match c {
+    'a' | 'e' | 'i' | 'o' | 'u' | 'A' | 'E' | 'I' | 'O' | 'U' => vowel(),
+    _ => consonant(),
+}
+```
+
+## MATCH-09 (MAY) — Reach for `Option::map` / `Result::map` over `match`
+
+```rust
+// VERBOSE
+let upper = match name {
+    Some(s) => Some(s.to_uppercase()),
+    None => None,
+};
+
+// IDIOMATIC
+let upper = name.map(|s| s.to_uppercase());
+```
+
+Same for `and_then`, `or_else`, `unwrap_or`, `unwrap_or_else`, `ok_or_else`, etc. Learn the combinator family. But: when the body is large (>5 lines) or involves error handling, `match` is clearer.
+
+## MATCH-10 (SHOULD) — `?` instead of `match` for `Result`/`Option` propagation
+
+Already covered in error handling but worth repeating here. Most "`match` returning `Err(e)`" or "`match` returning `None`" patterns should just be `?`.
+
+## MATCH-11 (MAY) — Use refutable patterns in `for` loops to filter
+
+```rust
+// IDIOMATIC
+for Ok(line) in reader.lines() { process(line); }   // silently skips Err
+
+// MORE EXPLICIT
+for line in reader.lines() {
+    match line {
+        Ok(s) => process(s),
+        Err(e) => tracing::warn!(?e, "skipping bad line"),
+    }
+}
+```
+
+The first form is concise but can mask bugs; prefer the explicit form unless dropping errors is genuinely fine.
+
+## MATCH-12 (SHOULD) — Avoid `panic!` from unreachable arms; use `unreachable!()` or refactor
+
+If you're writing `match` and one arm is "this can't happen," reach for `unreachable!()` *and* leave a comment explaining the invariant. Better: refactor so the impossible case isn't representable.
+
+```rust
+// OK with explanation
+match state {
+    State::Open(conn) => conn.send(msg),
+    State::Closed => unreachable!("send() requires open state; checked by guard"),
+}
+
+// BETTER — separate types per state
+fn send(open: &OpenConnection, msg: Msg) { … }
+```
+
+## MATCH-13 (SHOULD) — Pattern matching in closures with `|(a, b)|`
+
+```rust
+// VERBOSE
+pairs.iter().map(|pair| { let (k, v) = pair; format!("{k}={v}") });
+
+// IDIOMATIC
+pairs.iter().map(|(k, v)| format!("{k}={v}"));
+```

--- a/skills/idiomatic-rust-review/references/rule-index.md
+++ b/skills/idiomatic-rust-review/references/rule-index.md
@@ -1,0 +1,168 @@
+# Rule Index (quick lookup)
+
+All rules from the skill, in one searchable table. For full anti-pattern/pattern code, see the linked reference file.
+
+| ID | Severity | One-line rule | File |
+| --- | --- | --- | --- |
+| R-1 | MUST | No `unwrap`/`expect`/`panic!` in library code on user-input paths | SKILL.md |
+| R-2 | SHOULD | Accept most general input, return most specific output | SKILL.md |
+| R-3 | SHOULD | Use enums instead of booleans for domain state | SKILL.md |
+| R-4 | SHOULD | Newtypes for non-interchangeable domain values | SKILL.md |
+| R-5 | MUST | Don't fight the borrow checker with reflexive `.clone()` or `Rc<RefCell<>>` | SKILL.md |
+| R-6 | SHOULD | Prefer iterator chains over index-based loops | SKILL.md |
+| R-7 | MUST | Use `?` for error propagation, not `match` returning `Err(e)` | SKILL.md |
+| R-8 | SHOULD | Library errors use `thiserror`; application errors use `anyhow` | SKILL.md |
+| R-9 | SHOULD | Make illegal states unrepresentable | SKILL.md |
+| R-10 | SHOULD | Don't hold lock guards across `await` or in `if let` heads | SKILL.md |
+| R-11 | MAY | Aim for immutability; `let mut` is the exception | SKILL.md |
+| R-12 | SHOULD | Run Clippy and treat warnings as findings | SKILL.md |
+| ERR-01 | MUST | `Result` for recoverable errors, `panic!` for bugs | error-handling.md |
+| ERR-02 | MUST | No `unwrap`/`expect` on fallible ops in library code | error-handling.md |
+| ERR-03 | MUST | `?` propagates, not `match … return Err(e)` | error-handling.md |
+| ERR-04 | SHOULD | Library errors: `thiserror` enum with `#[from]`/`#[source]` | error-handling.md |
+| ERR-05 | SHOULD | Application errors: `anyhow::Result` with `.context()` | error-handling.md |
+| ERR-06 | SHOULD | Don't swallow errors with `.ok()` or `let _ =` | error-handling.md |
+| ERR-07 | SHOULD | `ok_or_else` over `ok_or` when the error allocates | error-handling.md |
+| ERR-08 | MAY | `Result<T, E>` over `Option<T>` when the reason matters | error-handling.md |
+| ERR-09 | SHOULD | Document `# Errors` and `# Panics` in rustdoc | error-handling.md |
+| ERR-10 | MUST | Panic-safety in `unsafe` and `Drop` | error-handling.md |
+| ERR-11 | MAY | Avoid `unwrap_or_default()` when it hides bugs | error-handling.md |
+| ERR-12 | SHOULD | `From` impls for error conversions, not manual `.map_err` | error-handling.md |
+| TYPE-01 | MUST | Newtype interchangeable primitives | types-and-conversions.md |
+| TYPE-02 | SHOULD | Enums instead of booleans for parameters | types-and-conversions.md |
+| TYPE-03 | SHOULD | `&str` parameters, `String` return values | types-and-conversions.md |
+| TYPE-04 | SHOULD | `impl AsRef<Path>` for file-path parameters | types-and-conversions.md |
+| TYPE-05 | SHOULD | Implement `From`, not `Into` | types-and-conversions.md |
+| TYPE-06 | SHOULD | `TryFrom`/`FromStr` for fallible conversions | types-and-conversions.md |
+| TYPE-07 | MUST | No blanket `From<T> for MyError` impls | types-and-conversions.md |
+| TYPE-08 | SHOULD | `&[T]` slice parameters, not `&Vec<T>` | types-and-conversions.md |
+| TYPE-09 | SHOULD | `impl IntoIterator<Item = T>` for consuming | types-and-conversions.md |
+| TYPE-10 | SHOULD | Newtypes derive `Debug`, `Clone`, and sometimes `Display` | types-and-conversions.md |
+| TYPE-11 | MAY | Separate DTO layer when wire shape differs from domain | types-and-conversions.md |
+| TYPE-12 | MUST | Never use floating-point for money | types-and-conversions.md |
+| TYPE-13 | SHOULD | Avoid `String` fields when an enum will do | types-and-conversions.md |
+| TYPE-14 | MAY | `NonZeroU32` etc. when zero is invalid | types-and-conversions.md |
+| OWN-01 | MUST | Don't `.clone()` away every borrow error | ownership-and-lifetimes.md |
+| OWN-02 | MUST | `Rc<RefCell<T>>` / `Arc<Mutex<T>>` are smells unless justified | ownership-and-lifetimes.md |
+| OWN-03 | SHOULD | Borrow inputs, own outputs | ownership-and-lifetimes.md |
+| OWN-04 | SHOULD | Take `self` by value to consume (builder finalize) | ownership-and-lifetimes.md |
+| OWN-05 | SHOULD | Elide lifetimes the compiler can infer | ownership-and-lifetimes.md |
+| OWN-06 | SHOULD | Name lifetimes descriptively in complex signatures | ownership-and-lifetimes.md |
+| OWN-07 | SHOULD | `'static` bounds are a design choice, not a default | ownership-and-lifetimes.md |
+| OWN-08 | SHOULD | Don't return references to local data (no `Box::leak` hacks) | ownership-and-lifetimes.md |
+| OWN-09 | MAY | `let mut` is the exception | ownership-and-lifetimes.md |
+| OWN-10 | SHOULD | `&[T]` not `&Vec<T>`; `&str` not `&String`; `&Path` not `&PathBuf` | ownership-and-lifetimes.md |
+| OWN-11 | SHOULD | Drop temporaries (locks!) explicitly when scope matters | ownership-and-lifetimes.md |
+| OWN-12 | MAY | `Cow<'_, T>` for sometimes-borrowed APIs | ownership-and-lifetimes.md |
+| OWN-13 | SHOULD | Self-referential structs are a smell | ownership-and-lifetimes.md |
+| OWN-14 | MAY | Prefer `&self` over `&mut self` over `self` | ownership-and-lifetimes.md |
+| ITER-01 | SHOULD | Iterator chains over index loops | iterators-and-collections.md |
+| ITER-02 | MUST | `collect::<Result<Vec<_>, _>>()` to short-circuit | iterators-and-collections.md |
+| ITER-03 | SHOULD | `flat_map` over `map().flatten()` | iterators-and-collections.md |
+| ITER-04 | SHOULD | `iter` / `iter_mut` / `into_iter` deliberately | iterators-and-collections.md |
+| ITER-05 | SHOULD | Don't `collect` and then re-iterate | iterators-and-collections.md |
+| ITER-06 | MAY | `sum`/`product`/`min`/`max` over manual `fold` | iterators-and-collections.md |
+| ITER-07 | SHOULD | `partition` to split into two collections | iterators-and-collections.md |
+| ITER-08 | SHOULD | `try_fold`/`try_for_each` for fallible reductions | iterators-and-collections.md |
+| ITER-09 | MUST | Don't `.nth()` in loops (O(n²)) | iterators-and-collections.md |
+| ITER-10 | SHOULD | `Vec::with_capacity` when size is known | iterators-and-collections.md |
+| ITER-11 | MAY | `HashMap::entry` for insert-or-update | iterators-and-collections.md |
+| ITER-12 | SHOULD | Match container choice to access pattern | iterators-and-collections.md |
+| ITER-13 | SHOULD | `windows`/`chunks` over manual indexing | iterators-and-collections.md |
+| ITER-14 | MAY | `.iter().enumerate()` reads better than the other order | iterators-and-collections.md |
+| ITER-15 | MAY | `rayon::par_iter` for embarrassingly parallel CPU work | iterators-and-collections.md |
+| API-01 | MUST | Derive `Debug` on every public type | api-design.md |
+| API-02 | SHOULD | Derive the standard quartet (Debug, Clone, PartialEq, Eq) | api-design.md |
+| API-03 | SHOULD | Builder pattern for >3 params or many optionals | api-design.md |
+| API-04 | SHOULD | `#[must_use]` on meaningful return values | api-design.md |
+| API-05 | SHOULD | Concrete return types, generic inputs | api-design.md |
+| API-06 | MUST | Don't expose internal types in public APIs | api-design.md |
+| API-07 | SHOULD | `#[non_exhaustive]` on public enums/structs that may grow | api-design.md |
+| API-08 | SHOULD | Sealed traits when no downstream impls wanted | api-design.md |
+| API-09 | SHOULD | `From`/`TryFrom` for conversions, not custom methods | api-design.md |
+| API-10 | MUST | Standard constructor naming: `new`, `try_new`, `from_*`, `with_*` | api-design.md |
+| API-11 | SHOULD | Re-export public types from the crate root | api-design.md |
+| API-12 | SHOULD | Respect orphan rule; don't impl foreign trait on foreign type | api-design.md |
+| API-13 | MAY | `Default` that matches `new()` | api-design.md |
+| API-14 | SHOULD | Return `&[T]`, not `&Vec<T>` | api-design.md |
+| API-15 | SHOULD | Return iterators over collections | api-design.md |
+| API-16 | MUST | Mark experimental APIs `#[doc(hidden)]` | api-design.md |
+| API-17 | MAY | Newtype-wrap third-party types in your public API | api-design.md |
+| API-18 | SHOULD | Match stdlib vocabulary (`as_*`, `to_*`, `into_*`, `len`, `is_empty`) | api-design.md |
+| ASYNC-01 | MUST | Don't hold `std::sync::Mutex` guards across `.await` | async-and-concurrency.md |
+| ASYNC-02 | MUST | Cancellation safety: every `.await` is a drop point | async-and-concurrency.md |
+| ASYNC-03 | SHOULD | Don't reach for `Arc<Mutex<>>` reflexively in async | async-and-concurrency.md |
+| ASYNC-04 | SHOULD | No blocking calls in async fns; use `spawn_blocking` | async-and-concurrency.md |
+| ASYNC-05 | MUST | Don't blindly `.unwrap()` `JoinHandle`s | async-and-concurrency.md |
+| ASYNC-06 | SHOULD | Relax `Send`/`Sync`/`'static` bounds when caller can choose | async-and-concurrency.md |
+| ASYNC-07 | SHOULD | Use `join!`/`try_join!`/`select!` correctly | async-and-concurrency.md |
+| ASYNC-08 | SHOULD | Bound channel sizes in production code | async-and-concurrency.md |
+| ASYNC-09 | MUST | No `block_on` inside an async context | async-and-concurrency.md |
+| ASYNC-10 | SHOULD | Use native `async fn` in traits (1.75+) or `async-trait` | async-and-concurrency.md |
+| ASYNC-11 | MAY | Don't async-everything; sync fns are fine | async-and-concurrency.md |
+| ASYNC-12 | SHOULD | `JoinSet` over fire-and-forget `spawn` | async-and-concurrency.md |
+| ASYNC-13 | MUST | `Pin` contracts: use `pin-project-lite` or document `unsafe` | async-and-concurrency.md |
+| ASYNC-14 | MAY | Threads are still valid for CPU work | async-and-concurrency.md |
+| MATCH-01 | MUST | No wildcard arms on closed enums you own | pattern-matching.md |
+| MATCH-02 | SHOULD | `if let` for one variant, `match` for two+ | pattern-matching.md |
+| MATCH-03 | SHOULD | `let-else` for early return on `None`/`Err` | pattern-matching.md |
+| MATCH-04 | SHOULD | `matches!` macro for boolean checks | pattern-matching.md |
+| MATCH-05 | MUST | Temporaries live until end of `if let`/`match` body | pattern-matching.md |
+| MATCH-06 | SHOULD | `@` bindings to capture+check together | pattern-matching.md |
+| MATCH-07 | SHOULD | Destructure in function parameters when natural | pattern-matching.md |
+| MATCH-08 | SHOULD | Combine match arms with `|` | pattern-matching.md |
+| MATCH-09 | MAY | `Option::map` / `Result::map` combinators over `match` | pattern-matching.md |
+| MATCH-10 | SHOULD | `?` over `match` for `Result`/`Option` propagation | pattern-matching.md |
+| MATCH-11 | MAY | Be careful with `for Ok(x) in iter` silently dropping errors | pattern-matching.md |
+| MATCH-12 | SHOULD | `unreachable!()` with comment, or refactor to remove the case | pattern-matching.md |
+| MATCH-13 | SHOULD | Pattern-match in closure args: `\|(a, b)\|` | pattern-matching.md |
+| DOC-01 | MUST | Every public item gets a doc comment | documentation-and-naming.md |
+| DOC-02 | MUST | First doc line is a single-sentence summary | documentation-and-naming.md |
+| DOC-03 | SHOULD | `# Errors` section on every fallible public fn | documentation-and-naming.md |
+| DOC-04 | SHOULD | `# Panics` section on anything that can panic | documentation-and-naming.md |
+| DOC-05 | MUST | `# Safety` section on every `pub unsafe fn` | documentation-and-naming.md |
+| DOC-06 | SHOULD | `# Examples` with working doctests | documentation-and-naming.md |
+| DOC-07 | SHOULD | Use intra-doc links `[`Type`]` | documentation-and-naming.md |
+| DOC-08 | MAY | Crate-level `//!` doc explains the concept | documentation-and-naming.md |
+| DOC-09 | SHOULD | Document complexity, allocation, thread-safety | documentation-and-naming.md |
+| DOC-10 | MUST | snake_case items, CamelCase types, SCREAMING_SNAKE_CASE consts | documentation-and-naming.md |
+| DOC-11 | SHOULD | Getters drop `get_`: `name()` not `get_name()` | documentation-and-naming.md |
+| DOC-12 | SHOULD | Type names: nouns. Trait names: capabilities/relationships. | documentation-and-naming.md |
+| DOC-13 | SHOULD | Avoid abbreviations except universally-known ones | documentation-and-naming.md |
+| DOC-14 | MAY | `_unused` over bare `_` when the name carries meaning | documentation-and-naming.md |
+| DOC-15 | SHOULD | README and `cargo doc` should agree | documentation-and-naming.md |
+| UNSAFE-01 | MUST | Every `unsafe` block needs a `// SAFETY:` comment | unsafe-and-performance.md |
+| UNSAFE-02 | MUST | `pub unsafe fn` needs `# Safety` doc | unsafe-and-performance.md |
+| UNSAFE-03 | MUST | Keep `unsafe` blocks small | unsafe-and-performance.md |
+| UNSAFE-04 | MUST | No `mem::transmute` when `as`/`bytemuck` works | unsafe-and-performance.md |
+| UNSAFE-05 | MUST | `_unchecked` methods need justification + profile + assertion | unsafe-and-performance.md |
+| UNSAFE-06 | MUST | Don't violate aliasing with `*mut` ↔ `&mut` | unsafe-and-performance.md |
+| UNSAFE-07 | SHOULD | `MaybeUninit<T>`, not `mem::uninitialized` | unsafe-and-performance.md |
+| UNSAFE-08 | SHOULD | Encapsulate `unsafe` behind a safe API | unsafe-and-performance.md |
+| UNSAFE-09 | MUST | FFI: catch panics; don't unwind across boundary | unsafe-and-performance.md |
+| UNSAFE-10 | SHOULD | Profile before optimizing | unsafe-and-performance.md |
+| UNSAFE-11 | MAY | Don't shrink-wrap allocations away from clarity | unsafe-and-performance.md |
+| UNSAFE-12 | SHOULD | Atomic ordering: be precise | unsafe-and-performance.md |
+| UNSAFE-13 | MUST | `unsafe impl Send/Sync` needs a SAFETY justification | unsafe-and-performance.md |
+| UNSAFE-14 | SHOULD | Run `cargo miri test` for `unsafe` code | unsafe-and-performance.md |
+| ANTI-01 | MUST | Don't trait-abstract for one impl | anti-patterns.md |
+| ANTI-02 | MUST | No premature `Arc<Mutex<>>` everywhere | anti-patterns.md |
+| ANTI-03 | SHOULD | No stringly-typed APIs | anti-patterns.md |
+| ANTI-04 | MUST | No `unwrap()` chains in production | anti-patterns.md |
+| ANTI-05 | SHOULD | No out-parameters; return new values | anti-patterns.md |
+| ANTI-06 | SHOULD | No `Box<dyn Error>` in library return types | anti-patterns.md |
+| ANTI-07 | MUST | Don't reinvent the stdlib | anti-patterns.md |
+| ANTI-08 | SHOULD | No index-based loops when iteration works | anti-patterns.md |
+| ANTI-09 | SHOULD | No `if x == true` / `match bool` | anti-patterns.md |
+| ANTI-10 | SHOULD | No `.to_string()` then immediately borrow | anti-patterns.md |
+| ANTI-11 | SHOULD | `to_string()` for single value, `format!` for composing | anti-patterns.md |
+| ANTI-12 | MUST | No `Box::leak` to fake `&'static` | anti-patterns.md |
+| ANTI-13 | SHOULD | Don't `clone()` arguments that the callee could borrow | anti-patterns.md |
+| ANTI-14 | MAY | Don't reach for macros when fns suffice | anti-patterns.md |
+| ANTI-15 | SHOULD | `if cond` over `match cond { true, false }` | anti-patterns.md |
+| ANTI-16 | SHOULD | Don't name variables `result`, `tmp`, `data`, `value` | anti-patterns.md |
+| ANTI-17 | SHOULD | `main() -> Result<()>` over `.unwrap()` chains | anti-patterns.md |
+| ANTI-18 | SHOULD | Group long parameter lists into a struct or builder | anti-patterns.md |
+| ANTI-19 | MAY | No trailing `return` at end of function | anti-patterns.md |
+| ANTI-20 | SHOULD | Don't builder-pattern two-field structs | anti-patterns.md |
+| ANTI-21 | MUST | `assert!(cond)` over `assert_eq!(cond, true)` | anti-patterns.md |

--- a/skills/idiomatic-rust-review/references/types-and-conversions.md
+++ b/skills/idiomatic-rust-review/references/types-and-conversions.md
@@ -1,0 +1,215 @@
+# Types & Conversions
+
+Sources: [The Ultimate Guide to Rust Newtypes](https://www.howtocodeit.com/articles/ultimate-guide-rust-newtypes), [Convenient and idiomatic conversions in Rust](https://ricardomartins.cc/2016/08/03/convenient_and_idiomatic_conversions_in_rust), [Taking string arguments in Rust](http://xion.io/post/code/rust-string-args.html), [When should I use String vs &str?](https://steveklabnik.com/writing/when-should-i-use-string-vs-str/), [Creating a Rust function that returns a &str or String](https://hermanradtke.com/2015/05/29/creating-a-rust-function-that-returns-string-or-str.html/), [Rust Patterns: Enums Instead Of Booleans](https://blakesmith.me/2019/05/07/rust-patterns-enums-instead-of-booleans.html), [Math with distances in Rust](https://www.ferrisellis.com/content/rust-implementing-units-for-types/), Rust API Guidelines (C-CONV).
+
+---
+
+## TYPE-01 (MUST) — Newtype interchangeable primitives that represent different domain concepts
+
+Two `u64`s representing a user ID and a duration in milliseconds should not be swappable. Newtypes are zero-cost (`#[repr(transparent)]`) and catch entire classes of bugs at compile time.
+
+```rust
+// BAD
+fn schedule(user_id: u64, retry_after_ms: u64) { … }
+schedule(retry_after_ms, user_id);  // compiles, ships, pages on-call
+
+// GOOD
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[repr(transparent)]
+pub struct UserId(pub u64);
+
+#[derive(Copy, Clone, Debug)]
+#[repr(transparent)]
+pub struct Millis(pub u64);
+
+fn schedule(user_id: UserId, retry_after: Millis) { … }
+```
+
+When the validation is non-trivial (email, port range, non-empty string), make the field private and expose a fallible constructor:
+
+```rust
+pub struct Port(u16);
+impl Port {
+    pub fn new(n: u16) -> Result<Self, OutOfRange> {
+        if (1024..49152).contains(&n) { Ok(Self(n)) } else { Err(OutOfRange) }
+    }
+    pub fn get(self) -> u16 { self.0 }
+}
+```
+
+Now anywhere the code has a `Port`, the value is known-valid.
+
+## TYPE-02 (SHOULD) — Enums instead of booleans for parameters
+
+A function with three `bool` parameters has 8 call-site combinations and zero readability. An enum is self-documenting and extensible.
+
+```rust
+// BAD
+fn render(html: bool, dark_mode: bool, compress: bool) { … }
+render(true, false, true);  // ???
+
+// GOOD
+enum Format { Html, Plain }
+enum Theme  { Light, Dark }
+enum Compression { On, Off }
+fn render(format: Format, theme: Theme, compression: Compression) { … }
+render(Format::Html, Theme::Light, Compression::On);
+```
+
+Bonus: callers who need a fourth format don't break source compatibility — they just gain a variant.
+
+## TYPE-03 (SHOULD) — `&str` parameters, `String` return values
+
+Default rule: take the cheapest type that lets the caller pass what they have; return the type the caller is most likely to want to own.
+
+```rust
+// BAD
+fn greet(name: String) -> &str { … }     // forces caller to allocate, lifetime headache on return
+
+// GOOD
+fn greet(name: &str) -> String { … }
+```
+
+Variants:
+
+- Accept *both* owned and borrowed with `impl Into<String>` when you'll store it.
+- Accept `impl AsRef<str>` when you'll only read it but want ergonomic call sites.
+- Return `Cow<'_, str>` when sometimes you can borrow and sometimes you must allocate.
+
+```rust
+pub fn normalize(s: &str) -> Cow<'_, str> {
+    if s.chars().all(|c| !c.is_uppercase()) {
+        Cow::Borrowed(s)            // no allocation when already normalized
+    } else {
+        Cow::Owned(s.to_lowercase())
+    }
+}
+```
+
+## TYPE-04 (SHOULD) — `impl AsRef<Path>` for file-path parameters
+
+```rust
+// BAD
+fn open_log(path: PathBuf) -> io::Result<File> { … }
+open_log(PathBuf::from("/var/log/app"));   // explicit conversion
+
+// GOOD
+fn open_log(path: impl AsRef<Path>) -> io::Result<File> { … }
+open_log("/var/log/app")?;                 // &str
+open_log(p)?;                              // &Path
+open_log(buf)?;                            // PathBuf
+```
+
+Same pattern for `impl AsRef<str>`, `impl AsRef<[u8]>`. The trait is implemented for the obvious types and conversion is zero-cost.
+
+## TYPE-05 (SHOULD) — Implement `From`, not `Into`
+
+`From<A> for B` automatically gives you `Into<B> for A`. The reverse isn't true. Always implement `From` — it composes better and shows up first in docs.
+
+```rust
+// GOOD
+impl From<u32> for UserId {
+    fn from(n: u32) -> Self { UserId(n as u64) }
+}
+// Now both `UserId::from(7u32)` and `let x: UserId = 7u32.into()` work.
+```
+
+For fallible conversions, do the same with `TryFrom`.
+
+## TYPE-06 (SHOULD) — `TryFrom` for fallible conversions, not custom `parse_*`
+
+Once `TryFrom` exists, the `?` operator and trait-based generics work everywhere. Custom `from_string` / `parse_email` methods scatter the same logic.
+
+```rust
+// BAD
+impl Email {
+    pub fn parse(s: &str) -> Result<Self, EmailError> { … }
+}
+
+// GOOD
+impl TryFrom<&str> for Email {
+    type Error = EmailError;
+    fn try_from(s: &str) -> Result<Self, Self::Error> { … }
+}
+impl FromStr for Email {  // bonus: enables `"x@y".parse::<Email>()`
+    type Err = EmailError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> { Self::try_from(s) }
+}
+```
+
+## TYPE-07 (MUST) — Don't `impl<T> From<T> for MyError`; it conflicts and surprises
+
+A blanket `From` on your error type breaks downstream attempts to add their own `From` impls and hides where errors actually originate. Use specific `From` impls for the underlying error types only.
+
+## TYPE-08 (SHOULD) — Prefer `Vec<T>` slice parameters as `&[T]`
+
+```rust
+// BAD
+fn sum(v: Vec<i64>) -> i64 { v.iter().sum() }
+sum(vec![1, 2, 3]);    // forced allocation
+// sum(&array);        // doesn't compile
+
+// GOOD
+fn sum(v: &[i64]) -> i64 { v.iter().sum() }
+sum(&[1, 2, 3]);
+sum(&my_vec);
+sum(&my_array[..]);
+```
+
+## TYPE-09 (SHOULD) — `impl IntoIterator<Item = T>` over `Vec<T>` when consuming
+
+Lets the caller pass arrays, iterators, or pre-built `Vec`s without converting.
+
+```rust
+// BAD
+fn bulk_insert(items: Vec<Item>) { … }
+
+// GOOD
+fn bulk_insert(items: impl IntoIterator<Item = Item>) { … }
+bulk_insert([item1, item2]);
+bulk_insert(stream.map(parse));
+bulk_insert(existing_vec);
+```
+
+## TYPE-10 (SHOULD) — Newtypes deserve `Debug`, `Clone` (if cheap), and sometimes `Display`
+
+Default derives for a value newtype:
+
+```rust
+#[derive(Debug, Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Order(u64);
+```
+
+`Display` is for *user-facing* formatting. `Debug` is for developer-facing. Don't conflate them. A `UserId` probably wants `Display` to print as `"user#42"`, and `Debug` to print as `UserId(42)`.
+
+## TYPE-11 (MAY) — Derive `serde::Serialize`/`Deserialize` only on data that crosses serialization boundaries
+
+Sprinkling `#[derive(Serialize, Deserialize)]` everywhere couples your internal types to your wire format. Keep a separate DTO layer and `impl From` between them when the public/wire shape differs from the domain.
+
+## TYPE-12 (MUST) — Never use floating-point for money
+
+`f64` can't represent `0.1` exactly. Use `i64` cents, `rust_decimal::Decimal`, or a newtype around an integer denomination.
+
+```rust
+// BAD
+let total: f64 = items.iter().map(|i| i.price).sum();
+
+// GOOD
+struct Cents(i64);
+let total: Cents = items.iter().map(|i| i.price).fold(Cents(0), |a, b| Cents(a.0 + b.0));
+```
+
+## TYPE-13 (SHOULD) — Avoid `String` fields when an enum will do
+
+```rust
+// BAD
+struct Job { status: String }   // "pending" / "Running" / "DONE  " — typos compile
+
+// GOOD
+enum Status { Pending, Running, Done, Failed { reason: String } }
+struct Job { status: Status }
+```
+
+## TYPE-14 (MAY) — Use `NonZeroU32` and friends when zero is invalid
+
+`Option<NonZeroU32>` is the same size as `u32` (niche optimization), and `NonZeroU32::new(0)` returns `None`. Free safety + free space.

--- a/skills/idiomatic-rust-review/references/unsafe-and-performance.md
+++ b/skills/idiomatic-rust-review/references/unsafe-and-performance.md
@@ -1,0 +1,170 @@
+# Unsafe & Performance
+
+Sources: [Pitfalls of Safe Rust](https://corrode.dev/blog/pitfalls-of-safe-rust/), [High Assurance Rust](https://highassurance.rs/), [Refactoring Rust Transpiled from C](https://immunant.com/blog/2020/09/transpiled_c_safety/), [The balance between cost, useability and soundness in C bindings](https://web.archive.org/web/20190509123207/https://cobrand.github.io/rust/sdl2/2017/05/07/the-balance-between-soundness-cost-useability.html), [Rust Atomics and Locks](https://marabos.nl/atomics/), Rust API Guidelines.
+
+---
+
+## UNSAFE-01 (MUST) — Every `unsafe` block needs a `// SAFETY:` comment
+
+The comment documents *why* the unsafe operation is sound, citing the invariants the caller must uphold (for `unsafe fn`) or that the surrounding code ensures (for `unsafe {}` blocks).
+
+```rust
+// BAD
+unsafe { std::slice::from_raw_parts(ptr, len) }
+
+// GOOD
+// SAFETY: `ptr` is non-null and points to `len` consecutive initialized `u8`s,
+// because it came from `Vec::as_ptr` of a vec we own with `len` elements.
+unsafe { std::slice::from_raw_parts(ptr, len) }
+```
+
+This is enforced by `clippy::undocumented_unsafe_blocks` at the `pedantic` level, which libraries should consider promoting to `deny`.
+
+## UNSAFE-02 (MUST) — `pub unsafe fn` requires a `# Safety` doc section
+
+See `DOC-05`. The two together (rustdoc `# Safety` + `// SAFETY:` at call sites) form the safety contract.
+
+## UNSAFE-03 (MUST) — `unsafe` blocks should be small
+
+Wrap only the operation that needs it, not the surrounding logic. This makes auditing tractable.
+
+```rust
+// BAD — entire function in unsafe
+unsafe fn process(ptr: *const u8, len: usize) -> u32 {
+    let s = std::slice::from_raw_parts(ptr, len);
+    let mut sum = 0;
+    for b in s { sum += *b as u32; }
+    sum
+}
+
+// GOOD — unsafe is one line
+fn process(ptr: *const u8, len: usize) -> u32 {
+    // SAFETY: caller guarantees `ptr` points to `len` valid bytes.
+    let s = unsafe { std::slice::from_raw_parts(ptr, len) };
+    s.iter().map(|&b| b as u32).sum()
+}
+```
+
+## UNSAFE-04 (MUST) — Don't `mem::transmute` when `as`, `cast`, or `bytemuck` will do
+
+`transmute` is the nuclear option. Most cases have safer alternatives:
+
+- Bit reinterpret of POD types → `bytemuck::cast` / `bytemuck::cast_slice`.
+- Numeric conversion → `as` (or `TryFrom` if you want overflow detection).
+- Pointer cast → `*const T as *const U`.
+- `&T` ↔ `&U` of same layout → `&*(p as *const U)` with documented invariants.
+
+Flag any `mem::transmute` that doesn't have a `// SAFETY:` comment explicitly justifying why the alternatives don't apply.
+
+## UNSAFE-05 (MUST) — `unwrap_unchecked` / `get_unchecked` / `*_unchecked` are footguns
+
+These bypass safety checks for performance. Acceptable only with:
+1. A `// SAFETY:` comment.
+2. A benchmark showing the safe version is actually a bottleneck.
+3. A `debug_assert!` of the invariant at the same call site.
+
+```rust
+// GOOD if and only if profiled
+debug_assert!(idx < v.len());
+// SAFETY: bounds checked by caller per the function precondition.
+let x = unsafe { *v.get_unchecked(idx) };
+```
+
+If the function is hot enough to warrant `_unchecked`, profile it. Otherwise use the safe variant.
+
+## UNSAFE-06 (MUST) — Don't violate aliasing rules with `*mut` ↔ `&mut`
+
+Holding a `&mut T` and a `&T` (or two `&mut T`s) to the same memory is undefined behavior, even if you got there through raw pointers. Tools: `miri`, `cargo +nightly miri test`.
+
+## UNSAFE-07 (SHOULD) — Use `MaybeUninit<T>` for partial initialization, not `mem::uninitialized`
+
+`mem::uninitialized` was deprecated for soundness reasons. `MaybeUninit` is the modern equivalent and lets the type system track initialization state.
+
+```rust
+// DEPRECATED & UB-PRONE
+let x: T = unsafe { mem::uninitialized() };
+
+// CORRECT
+let mut x = MaybeUninit::<T>::uninit();
+// ... initialize fields ...
+let x = unsafe { x.assume_init() };  // SAFETY: all fields initialized above
+```
+
+## UNSAFE-08 (SHOULD) — Encapsulate `unsafe` behind a safe API
+
+If your crate has 50 `unsafe` blocks, the user trusts your crate, not Rust. Concentrate the `unsafe` in a minimal core; expose a safe API on top.
+
+```rust
+// Safe wrapper
+pub struct Buffer { ptr: NonNull<u8>, len: usize }
+
+impl Buffer {
+    pub fn new(size: usize) -> Self { … }
+    pub fn write(&mut self, offset: usize, bytes: &[u8]) -> Result<(), Error> {
+        if offset + bytes.len() > self.len { return Err(Error::OutOfBounds); }
+        // SAFETY: bounds checked above.
+        unsafe { ptr::copy_nonoverlapping(bytes.as_ptr(), self.ptr.as_ptr().add(offset), bytes.len()); }
+        Ok(())
+    }
+}
+```
+
+## UNSAFE-09 (MUST) — FFI: don't unwind across the boundary
+
+A Rust panic that crosses an `extern "C"` boundary is UB. Use `std::panic::catch_unwind` or compile with `panic = "abort"`.
+
+```rust
+#[no_mangle]
+pub extern "C" fn do_thing() -> i32 {
+    std::panic::catch_unwind(|| {
+        // Rust code that might panic
+        compute()
+    }).unwrap_or(-1)
+}
+```
+
+## UNSAFE-10 (SHOULD) — Performance: profile before optimizing
+
+Idiomatic Rust is usually fast. Before reviewing for performance:
+1. Has the author run `cargo build --release`? (Debug builds are 10–100× slower.)
+2. Has the author profiled? Use `cargo flamegraph`, `perf`, `samply`, or `pprof`.
+3. Are they fighting a benchmark microoptimization, or a real bottleneck?
+
+Common honest wins (no `unsafe` needed):
+- `String::with_capacity` / `Vec::with_capacity` when size is known.
+- `&str` keys for `HashMap` lookups (avoid `String` allocation per lookup with `HashMap::raw_entry` or borrowing keys).
+- Replace `Vec::contains` with `HashSet` in hot inner loops.
+- Use `Box<[T]>` instead of `Vec<T>` for read-only owned arrays (saves capacity field).
+- `SmallVec` / `tinyvec` for "usually small" arrays.
+
+## UNSAFE-11 (MAY) — Don't shrink-wrap allocations away from clarity
+
+A `Cow<'a, [u8]>` to avoid one allocation in a non-hot path adds complexity at every use site. Only optimize what shows up in profiles.
+
+## UNSAFE-12 (SHOULD) — Atomic ordering: be precise
+
+`Ordering::Relaxed` doesn't synchronize. `Ordering::SeqCst` is correct but expensive. Most ad-hoc lock-free code wants `Acquire`/`Release` pairs. If the author wrote `SeqCst` everywhere without thought, that's a documentation/correctness flag. If they wrote `Relaxed` for a "happens-before" relationship, that's a bug.
+
+```rust
+// Producer-consumer pattern: Release on store, Acquire on load.
+flag.store(true, Ordering::Release);
+// ... in another thread ...
+if flag.load(Ordering::Acquire) { /* sees writes that happened before .store */ }
+```
+
+Read [Rust Atomics and Locks](https://marabos.nl/atomics/) before reviewing concurrent unsafe.
+
+## UNSAFE-13 (MUST) — `Send` / `Sync` manual impls require justification
+
+`unsafe impl Send for X` and `unsafe impl Sync for X` are `unsafe` for a reason. Every such impl needs a `// SAFETY:` comment explaining why the type is thread-safe.
+
+```rust
+// SAFETY: `Inner` is never aliased except through this struct's API,
+// which serializes access via the mutex in `Outer`.
+unsafe impl Send for Outer {}
+unsafe impl Sync for Outer {}
+```
+
+## UNSAFE-14 (SHOULD) — Run `cargo miri test` for unsafe code
+
+`miri` catches UB the compiler can't. Any crate with `unsafe` blocks should have miri in CI.


### PR DESCRIPTION
## Summary

This PR adds an installable [Claude Code](https://claude.com/claude-code) skill that turns the resources collected in this repository into an automated Rust code reviewer, plus the marketplace manifests needed so anyone can install it with a single command.

After this lands, users will be able to run `/plugin marketplace add mre/idiomatic-rust` followed by `/plugin install idiomatic-rust-review@idiomatic-rust` from Claude Code, and the skill will activate automatically whenever they paste Rust code or ask for a Rust review.

## What's included

- **`skills/idiomatic-rust-review/SKILL.md`** — a peer-reviewed ruleset (12 top-tier rules with severity tags `MUST` / `SHOULD` / `MAY`, a reviewer process checklist, a "what not to flag" list, and a structured output format) synthesized from this repository's corpus, the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/), [Canonical's Rust Best Practices](https://canonical.github.io/rust-best-practices/), [Elements of Rust](https://github.com/ferrous-systems/elements-of-rust), and [Clippy](https://github.com/rust-lang/rust-clippy).
- **`skills/idiomatic-rust-review/references/`** — 12 category files (error handling, types & conversions, ownership & lifetimes, iterators, API design, async & concurrency, pattern matching, documentation & naming, unsafe & performance, anti-patterns, a flat rule index, and a worked before/after example) that the reviewer loads on demand, with each rule citing its source from this corpus.
- **`.claude-plugin/marketplace.json`** + **`.claude-plugin/plugin.json`** — minimal Claude Code plugin manifests so the repo doubles as a plugin marketplace. The skill is sourced at `./`, so the existing `skills/` directory is auto-discovered.
- **`resources.json`** + **`render/templates/README.md`** — registers the skill as a project entry and adds a "🤖 Use as a Claude Code Skill" section to the rendered README with the install commands. README.md is regenerated via `make render`.

## Design notes

The skill ruleset is opinionated but deliberately conservative — it scopes which rules are `MUST` vs `SHOULD` vs `MAY`, tells reviewers to pick the 5–10 highest-value findings rather than nitpicking, and includes an explicit "what NOT to flag" list. Every rule cites the source resource it came from, most of which are already in `resources.json`, so the review output stays traceable to this corpus.

Plugin manifests are intentionally minimal (just `name`, `description`, `version`, owner). The plugin's `source` is `./` so adding more skills to this repo later is a one-line change to `marketplace.json`.

## Test plan

- [ ] `make render` runs cleanly and regenerates `README.md` with the new section and resource entry
- [ ] In Claude Code: `/plugin marketplace add mre/idiomatic-rust` resolves the manifest
- [ ] `/plugin install idiomatic-rust-review@idiomatic-rust` installs the skill from the marketplace
- [ ] After install, pasting a `.rs` snippet into Claude Code activates the skill and produces a review in the documented output format
- [ ] `/plugin uninstall idiomatic-rust-review@idiomatic-rust` cleanly removes it
- [ ] Existing CI (the Check Links workflow) still passes — no new external URLs were added that weren't already in the corpus